### PR TITLE
include org id

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kinde-oss/kinde-auth-pkce-js",
-  "version": "0.0.6",
+  "version": "0.0.9",
   "description": "Kinde PKCE authentication for SPAs",
   "module": "dist/kinde-auth-pkce-js.esm.min.js",
   "browser": "dist/kinde-auth-pkce-js.umd.min.js",

--- a/src/main.js
+++ b/src/main.js
@@ -14,7 +14,8 @@ const createKindeClient = async (options) => {
     redirect_uri,
     domain,
     is_live = true,
-    logout_uri = redirect_uri
+    logout_uri = redirect_uri,
+    org_id = -1
   } = options;
 
   if (!redirect_uri || typeof options.redirect_uri !== 'string') {
@@ -41,7 +42,8 @@ const createKindeClient = async (options) => {
     authorization_endpoint: `${domain}/oauth2/auth`,
     token_endpoint: `${domain}/oauth2/token`,
     requested_scopes: 'openid offline',
-    domain
+    domain,
+    org_id
   };
 
   const setupChallenge = async () => {
@@ -97,7 +99,8 @@ const createKindeClient = async (options) => {
       code_challenge,
       code_challenge_method: 'S256',
       state,
-      start_page: type
+      start_page: type,
+      org_id
     });
 
     window.location = url;

--- a/src/main.js
+++ b/src/main.js
@@ -87,9 +87,11 @@ const createKindeClient = async (options) => {
   await getToken();
 
   const handleKindeRedirect = async (options) => {
+    const {start_page, is_create_org, org_id, org_name = ''} = options;
+
     const {state, code_challenge, url} = await setupChallenge();
 
-    url.search = new URLSearchParams({
+    let searchParams = {
       redirect_uri,
       client_id,
       response_type: 'code',
@@ -97,26 +99,43 @@ const createKindeClient = async (options) => {
       code_challenge,
       code_challenge_method: 'S256',
       state,
-      start_page: options.type,
-      org_id: options.org_id
-    });
+      start_page
+    };
+
+    if (is_create_org) {
+      searchParams.is_create_org = is_create_org;
+      searchParams.org_name = org_name;
+    }
+
+    if (org_id) {
+      searchParams.org_id = org_id;
+    }
+
+    url.search = new URLSearchParams(searchParams);
 
     window.location = url;
   };
 
   const register = async (options) => {
     await handleKindeRedirect({
-      type: 'register',
-      ...options
+      ...options,
+      start_page: 'registration'
     });
   };
 
   const login = async (options) => {
     await handleKindeRedirect({
-      type: 'login',
-      ...options
+      ...options,
+      start_page: 'login'
     });
-    console.log('options', options);
+  };
+
+  const createOrg = async (options) => {
+    await handleKindeRedirect({
+      ...options,
+      start_page: 'registration',
+      is_create_org: true
+    });
   };
 
   const handleRedirectCallback = async () => {
@@ -210,7 +229,8 @@ const createKindeClient = async (options) => {
     handleRedirectCallback,
     login,
     logout,
-    register
+    register,
+    createOrg
   };
 };
 

--- a/src/main.js
+++ b/src/main.js
@@ -14,8 +14,7 @@ const createKindeClient = async (options) => {
     redirect_uri,
     domain,
     is_live = true,
-    logout_uri = redirect_uri,
-    org_id = -1
+    logout_uri = redirect_uri
   } = options;
 
   if (!redirect_uri || typeof options.redirect_uri !== 'string') {
@@ -42,8 +41,7 @@ const createKindeClient = async (options) => {
     authorization_endpoint: `${domain}/oauth2/auth`,
     token_endpoint: `${domain}/oauth2/token`,
     requested_scopes: 'openid offline',
-    domain,
-    org_id
+    domain
   };
 
   const setupChallenge = async () => {
@@ -88,7 +86,7 @@ const createKindeClient = async (options) => {
 
   await getToken();
 
-  const handleKindeRedirect = async (type) => {
+  const handleKindeRedirect = async (options) => {
     const {state, code_challenge, url} = await setupChallenge();
 
     url.search = new URLSearchParams({
@@ -99,19 +97,26 @@ const createKindeClient = async (options) => {
       code_challenge,
       code_challenge_method: 'S256',
       state,
-      start_page: type,
-      org_id
+      start_page: options.type,
+      org_id: options.org_id
     });
 
     window.location = url;
   };
 
-  const register = async () => {
-    await handleKindeRedirect('registration');
+  const register = async (options) => {
+    await handleKindeRedirect({
+      type: 'register',
+      ...options
+    });
   };
 
-  const login = async () => {
-    await handleKindeRedirect('login');
+  const login = async (options) => {
+    await handleKindeRedirect({
+      type: 'login',
+      ...options
+    });
+    console.log('options', options);
   };
 
   const handleRedirectCallback = async () => {


### PR DESCRIPTION
- Include org id in `handleKindeRedirect`.
- Org id can be passed into `createKindeClient`.
- If undefined, `org_id` defaults to `-1`.
- Here is a ss of the query string params with `org_id`: https://gyazo.com/f8094c67d411e4d614c8e57599f17500