### PR TITLE
Enforce redirect uri match 

### DIFF
--- a/src/createKindeClient.ts
+++ b/src/createKindeClient.ts
@@ -1,4 +1,18 @@
+import {version} from './utils/version';
 import {SESSION_PREFIX} from './constants/index';
+import {
+  type JWT,
+  isValidJwt,
+  parseJwt,
+  setupChallenge,
+  getClaim,
+  getClaimValue,
+  getUserOrganizations,
+  getIntegerFlag,
+  getStringFlag,
+  getBooleanFlag,
+  getFlag
+} from './utils/index';
 import {store} from './state/store';
 import type {
   AuthOptions,
@@ -12,20 +26,6 @@ import type {
   OrgOptions,
   RedirectOptions
 } from './types';
-import {
-  getBooleanFlag,
-  getClaim,
-  getClaimValue,
-  getFlag,
-  getIntegerFlag,
-  getStringFlag,
-  getUserOrganizations,
-  isValidJwt,
-  parseJwt,
-  setupChallenge,
-  type JWT
-} from './utils/index';
-import {version} from './utils/version';
 
 const createKindeClient = async (
   options: KindeClientOptions

--- a/src/createKindeClient.ts
+++ b/src/createKindeClient.ts
@@ -47,6 +47,7 @@ const createKindeClient = async (
     logout_uri = redirect_uri,
     on_redirect_callback,
     scope = 'openid profile email offline',
+    enforce_redirect_uri_match,
     _framework,
     _frameworkVersion
   } = options;
@@ -386,7 +387,7 @@ const createKindeClient = async (
   const init = async () => {
     const q = new URLSearchParams(window.location.search);
     // Is a redirect from Kinde Auth server
-    if (q.has('code')) {
+    if (isKindeRedirect(q)) {
       await handleRedirectToApp(q);
     } else {
       // For onload / new tab / page refresh
@@ -394,6 +395,17 @@ const createKindeClient = async (
         await useRefreshToken();
       }
     }
+  };
+
+  const isKindeRedirect = (searchParams: URLSearchParams) => {
+    const hasOauthCode = searchParams.has('code');
+    if (!hasOauthCode) return false;
+
+    if (!enforce_redirect_uri_match) return true;
+    // Optional check if redirect_uri match current url
+    const {protocol, host, pathname} = window.location;
+    const currentRedirectUri = `${protocol}//${host}${pathname}`;
+    return currentRedirectUri === redirect_uri;
   };
 
   await init();

--- a/src/createKindeClient.ts
+++ b/src/createKindeClient.ts
@@ -1,18 +1,4 @@
-import {version} from './utils/version';
 import {SESSION_PREFIX} from './constants/index';
-import {
-  type JWT,
-  isValidJwt,
-  parseJwt,
-  setupChallenge,
-  getClaim,
-  getClaimValue,
-  getUserOrganizations,
-  getIntegerFlag,
-  getStringFlag,
-  getBooleanFlag,
-  getFlag
-} from './utils/index';
 import {store} from './state/store';
 import type {
   AuthOptions,
@@ -26,6 +12,20 @@ import type {
   OrgOptions,
   RedirectOptions
 } from './types';
+import {
+  getBooleanFlag,
+  getClaim,
+  getClaimValue,
+  getFlag,
+  getIntegerFlag,
+  getStringFlag,
+  getUserOrganizations,
+  isValidJwt,
+  parseJwt,
+  setupChallenge,
+  type JWT
+} from './utils/index';
+import {version} from './utils/version';
 
 const createKindeClient = async (
   options: KindeClientOptions
@@ -47,7 +47,6 @@ const createKindeClient = async (
     logout_uri = redirect_uri,
     on_redirect_callback,
     scope = 'openid profile email offline',
-    enforce_redirect_uri_match,
     _framework,
     _frameworkVersion
   } = options;
@@ -398,11 +397,11 @@ const createKindeClient = async (
   };
 
   const isKindeRedirect = (searchParams: URLSearchParams) => {
+    // Check if the search params hve the code parameter
     const hasOauthCode = searchParams.has('code');
     if (!hasOauthCode) return false;
 
-    if (!enforce_redirect_uri_match) return true;
-    // Optional check if redirect_uri match current url
+    // Also check if redirect_uri matches current url
     const {protocol, host, pathname} = window.location;
     const currentRedirectUri = `${protocol}//${host}${pathname}`;
     return currentRedirectUri === redirect_uri;

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,6 +24,7 @@ export type KindeClientOptions = {
   logout_uri?: string;
   on_redirect_callback?: (user: KindeUser, appState?: object) => void;
   scope?: string;
+  enforce_redirect_uri_match?: boolean;
   _framework?: string;
   _frameworkVersion?: string;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,7 +24,6 @@ export type KindeClientOptions = {
   logout_uri?: string;
   on_redirect_callback?: (user: KindeUser, appState?: object) => void;
   scope?: string;
-  enforce_redirect_uri_match?: boolean;
   _framework?: string;
   _frameworkVersion?: string;
 };


### PR DESCRIPTION
# Explain your changes
Fixes #47  by adding an optional enforce redirect uri match boolean to Kinde client options.

This variable adds an extra check into the Kinde Client init method that will ensure the window.location matches the redirect URI.

This will ensure it does not hijack any other OAuth flows.

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
