### PR TITLE
Add getIdToken method

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -96,6 +96,7 @@ export type RedirectOptions = OrgOptions &
 
 export type KindeClient = {
   getToken: () => Promise<string | undefined>;
+  getIdToken: () => Promise<string | undefined>;
   isAuthenticated: () => Promise<boolean>;
   getUser: () => KindeUser;
   getUserProfile: () => Promise<KindeUser | undefined>;


### PR DESCRIPTION
# Explain your changes

I've raised a support thread in Discord: https://discord.com/channels/1070212618549219328/1179456563627438141

> [...]can you help me understand how to use and validate the ID Token (https://kinde.com/docs/build/about-id-tokens/) ? I'm already passing the Access Token to my REST API through the "authorization" HTTP header. However, this token doesn't contain the user's email address (https://kinde.com/docs/build/about-access-tokens/) and so on every REST API call I'm currently getting a M2M token and calling the Kinde API to get the user object to get their email address. The ID token includes the user's email address (https://kinde.com/docs/build/about-id-tokens/) but I can't see any example in your docs of the recommended way of passing this token through to a REST API and validate serverside that the ID token is valid.

This PR exposes a new `getIdToken()` method which returns the complete ID Token: https://kinde.com/docs/build/about-id-tokens/

# Checklist

- [X] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [X] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
