### PR TITLE
Update `start_page` to spec `prompt`

### DIFF
--- a/src/createKindeClient.ts
+++ b/src/createKindeClient.ts
@@ -322,7 +322,7 @@ const createKindeClient = async (
   const redirectToKinde = async (options: RedirectOptions) => {
     const {
       app_state,
-      start_page,
+      prompt,
       is_create_org,
       org_name = '',
       org_code,
@@ -343,8 +343,8 @@ const createKindeClient = async (
       state
     };
 
-    if (start_page) {
-      searchParams.start_page = start_page;
+    if (prompt) {
+      searchParams.prompt = prompt;
     }
 
     if (org_code) {
@@ -377,7 +377,7 @@ const createKindeClient = async (
   const register = async (options?: AuthOptions) => {
     await redirectToKinde({
       ...options,
-      start_page: 'registration'
+      prompt: 'create'
     });
   };
 
@@ -390,7 +390,7 @@ const createKindeClient = async (
   const createOrg = async (options?: OrgOptions) => {
     await redirectToKinde({
       ...options,
-      start_page: 'registration',
+      prompt: 'create',
       is_create_org: true
     });
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -90,7 +90,7 @@ export type AuthOptions = {
 
 export type RedirectOptions = OrgOptions &
   AuthOptions & {
-    start_page?: string;
+    prompt?: string;
     is_create_org?: boolean;
   };
 


### PR DESCRIPTION
# Summary

OAuth spec now accepts `create` as an argument to the `prompt` param to indicate a registration. Updated SDK to use this

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **Refactor**
	- Updated the redirection and prompting actions for a smoother user experience.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->