### PR TITLE
Add options to getToken always force refresh

### DIFF
--- a/src/createKindeClient.ts
+++ b/src/createKindeClient.ts
@@ -27,7 +27,8 @@ import type {
   KindeState,
   KindeUser,
   OrgOptions,
-  RedirectOptions
+  RedirectOptions,
+  GetTokenOptions
 } from './types';
 
 const createKindeClient = async (
@@ -195,10 +196,13 @@ const createKindeClient = async (
     }
   };
 
-  const getTokenType = async (tokenType: storageMap) => {
+  const getTokenType = async (
+    tokenType: storageMap,
+    options: GetTokenOptions
+  ) => {
     const token = store.getItem(storageMap.token_bundle) as KindeState;
 
-    if (!token) {
+    if (!token || options.isForceRefresh) {
       return await useRefreshToken({tokenType});
     }
 
@@ -214,12 +218,12 @@ const createKindeClient = async (
     }
   };
 
-  const getToken = async () => {
-    return await getTokenType(storageMap.access_token);
+  const getToken = async (options: GetTokenOptions) => {
+    return await getTokenType(storageMap.access_token, options);
   };
 
-  const getIdToken = async () => {
-    return await getTokenType(storageMap.id_token);
+  const getIdToken = async (options: GetTokenOptions) => {
+    return await getTokenType(storageMap.id_token, options);
   };
 
   const isAuthenticated = async () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -88,6 +88,10 @@ export type AuthOptions = {
   authUrlParams?: object;
 };
 
+export type GetTokenOptions = {
+  isForceRefresh?: boolean;
+};
+
 export type RedirectOptions = OrgOptions &
   AuthOptions & {
     prompt?: string;


### PR DESCRIPTION
# Explain your changes

The forceRefresh option will always call the Kinde token endpoint to get the latest version of the tokens

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
