### PR TITLE
Changed audience check to check against each configured audience, updated tests

### DIFF
--- a/src/utils/isTokenValid/isIDTokenValid.test.ts
+++ b/src/utils/isTokenValid/isIDTokenValid.test.ts
@@ -3,7 +3,7 @@ import {isTokenValid} from './isTokenValid';
 
 const config = {
   iss: 'https://account.acme.com',
-  aud: 'https://account.acme.com',
+  aud: 'https://account.acme.com 123456789',
   azp: '123456789'
 };
 
@@ -111,7 +111,7 @@ describe('isIDToken valid', () => {
         config
       );
     }).toThrow(
-      `(aud) claim mismatch. Expected: "https://account.acme.com", Received: "mate"`
+      `(aud) claim mismatch. Expected: "https://account.acme.com 123456789", Received: "mate"`
     );
   });
 

--- a/src/utils/isTokenValid/isTokenValid.ts
+++ b/src/utils/isTokenValid/isTokenValid.ts
@@ -29,7 +29,11 @@ const isTokenValid = (token: any, config: any) => {
       throw new Error('(aud) claim must be an array');
     }
 
-    if (!token.payload.aud.includes(config.aud)) {
+    if (
+      !token.payload.aud.every((element: string) =>
+        config.aud.includes(element)
+      )
+    ) {
       throw new Error(
         `(aud) claim mismatch. Expected: "${
           config.aud


### PR DESCRIPTION
# Fix multiple audiences error

Fixes #69 - When using multiple audiences we get a "(aud) claim mismatch" error

# Checklist

- [ X] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [ X] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
