### PR TITLE
Prevent unneeded calls to token endpoint

### DIFF
--- a/src/utils/hasCookie/hasCookie.ts
+++ b/src/utils/hasCookie/hasCookie.ts
@@ -1,7 +1,7 @@
 const hasCookie = (name: string) =>
   document.cookie
     .split('; ')
-    .find((row) => row.startsWith(`${name}=`))
+    .find((row) => row.split('=')[0] === name)
     ?.split('=')[1];
 
 export {hasCookie};

--- a/src/utils/hasCookie/hasCookie.ts
+++ b/src/utils/hasCookie/hasCookie.ts
@@ -1,0 +1,7 @@
+const hasCookie = (name: string) =>
+  document.cookie
+    .split('; ')
+    .find((row) => row.startsWith(`${name}=`))
+    ?.split('=')[1];
+
+export {hasCookie};


### PR DESCRIPTION
# Explain your changes

For custom domains we store the refresh token in a secure, httpOnly cookie which cannot be read by client-side JavaScript. The upshot of this is that we optimistically called the token endpoint causing unnecessary additional requests.

We now added an additional cookie containing no sensitive data that essentially is a flag to indicate the presence of the refresh token cookie so we only call the token endpoint when this exists

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
