### PR TITLE
fix: audience check when checking specific

### DIFF
--- a/src/utils/isTokenValid/isIDTokenValid.test.ts
+++ b/src/utils/isTokenValid/isIDTokenValid.test.ts
@@ -115,6 +115,21 @@ describe('isIDToken valid', () => {
     );
   });
 
+  test("Extra aud values don't throw", () => {
+    expect(
+      isTokenValid(
+        {
+          header,
+          payload: {
+            ...idTokenStub,
+            aud: ['https://account.acme.com', '123456789']
+          }
+        },
+        config
+      )
+    ).toBe(true);
+  });
+
   test('Throw error if token expired', () => {
     expect(() => {
       isTokenValid(

--- a/src/utils/isTokenValid/isTokenValid.ts
+++ b/src/utils/isTokenValid/isTokenValid.ts
@@ -29,11 +29,13 @@ const isTokenValid = (token: any, config: any) => {
       throw new Error('(aud) claim must be an array');
     }
 
-    if (
-      !token.payload.aud.every((element: string) =>
-        config.aud.includes(element)
-      )
-    ) {
+    const configAud = config.aud.split(' ');
+
+    const allConfigAudExistInPayload = configAud.every((element: string) =>
+      token.payload.aud.includes(element)
+    );
+
+    if (!allConfigAudExistInPayload) {
       throw new Error(
         `(aud) claim mismatch. Expected: "${
           config.aud


### PR DESCRIPTION
# Explain your changes

Changed the logic so when checking for audience, it more are in the token it doesn't throw.

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
