### PR TITLE
Add invitation functionality to createKindeClient

### DIFF
--- a/src/createKindeClient.test.ts
+++ b/src/createKindeClient.test.ts
@@ -1,0 +1,158 @@
+jest.mock('./utils/index', () => ({
+  setupChallenge: jest.fn(),
+  isJWTActive: jest.fn(),
+  getClaim: jest.fn(),
+  getClaimValue: jest.fn(),
+  getUserOrganizations: jest.fn(),
+  getIntegerFlag: jest.fn(),
+  getStringFlag: jest.fn(),
+  getBooleanFlag: jest.fn(),
+  getFlag: jest.fn(),
+  isTokenValid: jest.fn(() => true),
+  isCustomDomain: jest.fn(() => false)
+}));
+
+jest.mock('@kinde/js-utils', () => ({
+  generatePortalUrl: jest.fn(),
+  GeneratePortalUrlParams: {},
+  MemoryStorage: jest.fn().mockImplementation(() => ({
+    setStore: jest.fn(),
+    getStore: jest.fn()
+  })),
+  setActiveStorage: jest.fn(),
+  StorageKeys: {
+    accessToken: 'accessToken'
+  }
+}));
+
+import createKindeClient from './createKindeClient';
+import {setupChallenge} from './utils/index';
+import {setActiveStorage} from '@kinde/js-utils';
+
+const mockSetupChallenge = setupChallenge as jest.Mock;
+const mockSetActiveStorage = setActiveStorage as jest.Mock;
+
+type StorageMock = {
+  getItem: jest.Mock;
+  setItem: jest.Mock;
+  removeItem: jest.Mock;
+  clear: jest.Mock;
+};
+
+const createStorageMock = (): StorageMock => ({
+  getItem: jest.fn(() => null),
+  setItem: jest.fn(),
+  removeItem: jest.fn(),
+  clear: jest.fn()
+});
+
+const setWindowLocation = (search = '') => {
+  const location = {
+    href: `http://localhost:3000/${search}`,
+    search,
+    hostname: 'localhost',
+    pathname: '/',
+    protocol: 'http:',
+    host: 'localhost:3000',
+    toString() {
+      return this.href;
+    }
+  };
+
+  Object.defineProperty(global, 'window', {
+    value: {
+      location,
+      history: {
+        pushState: jest.fn()
+      }
+    },
+    writable: true,
+    configurable: true
+  });
+
+  Object.defineProperty(global, 'location', {
+    value: location,
+    writable: true,
+    configurable: true
+  });
+
+  return location;
+};
+
+describe('createKindeClient invitation flow', () => {
+  beforeEach(() => {
+    mockSetupChallenge.mockResolvedValue({
+      state: 'state-123',
+      code_challenge: 'challenge-123',
+      url: new URL('https://example.kinde.com/oauth2/auth')
+    });
+    mockSetActiveStorage.mockReset();
+    Object.defineProperty(global, 'sessionStorage', {
+      value: createStorageMock(),
+      writable: true,
+      configurable: true
+    });
+    Object.defineProperty(global, 'localStorage', {
+      value: createStorageMock(),
+      writable: true,
+      configurable: true
+    });
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('starts a new auth flow when invitation_code is present in the URL', async () => {
+    setWindowLocation('?invitation_code=invite-123&foo=bar');
+
+    await createKindeClient({
+      domain: 'https://example.kinde.com',
+      redirect_uri: 'http://localhost:3000/'
+    });
+
+    expect(mockSetupChallenge).toHaveBeenCalledWith(
+      'https://example.kinde.com/oauth2/auth',
+      expect.objectContaining({
+        kindeOriginUrl: 'http://localhost:3000/?foo=bar'
+      })
+    );
+
+    const redirectedUrl = new URL(
+      (window as typeof globalThis & {location: Location}).location.href
+    );
+
+    expect(redirectedUrl.searchParams.get('invitation_code')).toBe(
+      'invite-123'
+    );
+    expect(redirectedUrl.searchParams.get('is_invitation')).toBe('true');
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('passes invitation params through manual login calls without mutating custom params', async () => {
+    setWindowLocation();
+    const authUrlParams = {connection_id: 'conn_123'};
+
+    const client = await createKindeClient({
+      domain: 'https://example.kinde.com',
+      redirect_uri: 'http://localhost:3000/'
+    });
+
+    await client.login({
+      invitation_code: 'invite-456',
+      authUrlParams
+    });
+
+    const redirectedUrl = new URL(
+      (window as typeof globalThis & {location: Location}).location.href
+    );
+
+    expect(redirectedUrl.searchParams.get('invitation_code')).toBe(
+      'invite-456'
+    );
+    expect(redirectedUrl.searchParams.get('is_invitation')).toBe('true');
+    expect(redirectedUrl.searchParams.get('connection_id')).toBe('conn_123');
+    expect(authUrlParams).toEqual({connection_id: 'conn_123'});
+  });
+});

--- a/src/createKindeClient.test.ts
+++ b/src/createKindeClient.test.ts
@@ -105,7 +105,7 @@ describe('createKindeClient invitation flow', () => {
   });
 
   it('starts a new auth flow when invitation_code is present in the URL', async () => {
-    setWindowLocation('?invitation_code=invite-123&foo=bar');
+    setWindowLocation('?invitation_code=invite-123&is_invitation=true&foo=bar');
 
     await createKindeClient({
       domain: 'https://example.kinde.com',

--- a/src/createKindeClient.ts
+++ b/src/createKindeClient.ts
@@ -289,6 +289,13 @@ const createKindeClient = async (
     window.history.pushState({}, '', url);
   };
 
+  const getKindeOriginUrl = () => {
+    const url = new URL(window.location.toString());
+    url.searchParams.delete('invitation_code');
+    url.searchParams.delete('is_invitation');
+    return url.toString();
+  };
+
   const handleRedirectToApp = async (q: URLSearchParams) => {
     const code = q.get('code')!;
     const state = q.get('state');
@@ -386,11 +393,12 @@ const createKindeClient = async (
       is_create_org,
       org_name = '',
       org_code,
+      invitation_code,
       authUrlParams = {}
     } = options;
 
     if (!app_state.kindeOriginUrl) {
-      app_state.kindeOriginUrl = window.location.href;
+      app_state.kindeOriginUrl = getKindeOriginUrl();
     }
 
     const {state, code_challenge, url} = await setupChallenge(
@@ -417,14 +425,20 @@ const createKindeClient = async (
       searchParams.org_code = org_code;
     }
 
+    if (invitation_code) {
+      searchParams.invitation_code = invitation_code;
+      searchParams.is_invitation = 'true';
+    }
+
     if (is_create_org) {
       searchParams.is_create_org = String(is_create_org);
       searchParams.org_name = org_name;
     }
 
-    const urlSearchParams = new URLSearchParams(
-      Object.assign(authUrlParams, searchParams)
-    );
+    const urlSearchParams = new URLSearchParams({
+      ...(authUrlParams as Record<string, string>),
+      ...searchParams
+    });
 
     if (audience) {
       /* if multiple audiences requested it should appear multiple times in the query string */
@@ -552,6 +566,13 @@ const createKindeClient = async (
     // Is a redirect from Kinde Auth server
     if (isKindeRedirect(q)) {
       await handleRedirectToApp(q);
+      return;
+    }
+
+    const invitationCode = q.get('invitation_code');
+    if (invitationCode) {
+      await login({invitation_code: invitationCode});
+      return;
     } else {
       // For onload / new tab / page refresh
       if (isUseCookie || isUseLocalStorage) {

--- a/src/createKindeClient.ts
+++ b/src/createKindeClient.ts
@@ -296,6 +296,14 @@ const createKindeClient = async (
     return url.toString();
   };
 
+  const normalizeAuthUrlParams = (
+    authUrlParams: NonNullable<AuthOptions['authUrlParams']>
+  ) => {
+    return Object.fromEntries(
+      Object.entries(authUrlParams).map(([key, value]) => [key, String(value)])
+    );
+  };
+
   const handleRedirectToApp = async (q: URLSearchParams) => {
     const code = q.get('code')!;
     const state = q.get('state');
@@ -436,7 +444,7 @@ const createKindeClient = async (
     }
 
     const urlSearchParams = new URLSearchParams({
-      ...(authUrlParams as Record<string, string>),
+      ...normalizeAuthUrlParams(authUrlParams),
       ...searchParams
     });
 

--- a/src/testData/accessTokenStub.ts
+++ b/src/testData/accessTokenStub.ts
@@ -1,7 +1,9 @@
+const nowInSeconds = Math.floor(Date.now() / 1000);
+
 const accessTokenStub = {
   aud: ['stake:prod-api'],
   azp: '1234567890',
-  exp: 1772323199,
+  exp: nowInSeconds + 60 * 60,
   feature_flags: {
     theme: {
       t: 's',
@@ -16,7 +18,7 @@ const accessTokenStub = {
       v: 5
     }
   },
-  iat: 123456789,
+  iat: nowInSeconds - 60,
   iss: 'https://app.acme.com',
   jti: '1234-12-12-12-123456',
   org_code: 'org_1234567890',

--- a/src/testData/accessTokenStub.ts
+++ b/src/testData/accessTokenStub.ts
@@ -1,35 +1,37 @@
-const nowInSeconds = Math.floor(Date.now() / 1000);
+const getAccessTokenStub = () => {
+  const nowInSeconds = Math.floor(Date.now() / 1000);
 
-const accessTokenStub = {
-  aud: ['stake:prod-api'],
-  azp: '1234567890',
-  exp: nowInSeconds + 60 * 60,
-  feature_flags: {
-    theme: {
-      t: 's',
-      v: 'pink'
+  return {
+    aud: ['stake:prod-api'],
+    azp: '1234567890',
+    exp: nowInSeconds + 60 * 60,
+    feature_flags: {
+      theme: {
+        t: 's',
+        v: 'pink'
+      },
+      is_dark_mode: {
+        t: 'b',
+        v: true
+      },
+      competitions_limit: {
+        t: 'i',
+        v: 5
+      }
     },
-    is_dark_mode: {
-      t: 'b',
-      v: true
-    },
-    competitions_limit: {
-      t: 'i',
-      v: 5
-    }
-  },
-  iat: nowInSeconds - 60,
-  iss: 'https://app.acme.com',
-  jti: '1234-12-12-12-123456',
-  org_code: 'org_1234567890',
-  permissions: [
-    'create:competitions',
-    'delete:competitions',
-    'view:stats',
-    'invite:users'
-  ],
-  scp: ['openid', 'profile', 'email', 'offline'],
-  sub: 'kp:1234567654345678'
+    iat: nowInSeconds - 60,
+    iss: 'https://app.acme.com',
+    jti: '1234-12-12-12-123456',
+    org_code: 'org_1234567890',
+    permissions: [
+      'create:competitions',
+      'delete:competitions',
+      'view:stats',
+      'invite:users'
+    ],
+    scp: ['openid', 'profile', 'email', 'offline'],
+    sub: 'kp:1234567654345678'
+  };
 };
 
-export {accessTokenStub};
+export {getAccessTokenStub};

--- a/src/testData/idTokenStub.ts
+++ b/src/testData/idTokenStub.ts
@@ -1,23 +1,25 @@
-const nowInSeconds = Math.floor(Date.now() / 1000);
+const getIdTokenStub = () => {
+  const nowInSeconds = Math.floor(Date.now() / 1000);
 
-const idTokenStub = {
-  at_hash: '-p1234',
-  aud: ['https://account.acme.com', '123456789'],
-  auth_time: nowInSeconds - 60,
-  azp: '123456789',
-  email: 'jaime@lannister.com',
-  exp: nowInSeconds + 60 * 60,
-  family_name: 'Lannister',
-  given_name: 'Jaime',
-  iat: nowInSeconds - 60,
-  iss: 'https://account.acme.com',
-  jti: '123-1-1-123-1234',
-  name: 'Jaime Lannister',
-  org_codes: ['org_1235', 'org_7890'],
-  picture: 'https://some-image.com',
-  provided_id: '1',
-  sub: 'kp:123456',
-  updated_at: 1683631328
+  return {
+    at_hash: '-p1234',
+    aud: ['https://account.acme.com', '123456789'],
+    auth_time: nowInSeconds - 60,
+    azp: '123456789',
+    email: 'jaime@lannister.com',
+    exp: nowInSeconds + 60 * 60,
+    family_name: 'Lannister',
+    given_name: 'Jaime',
+    iat: nowInSeconds - 60,
+    iss: 'https://account.acme.com',
+    jti: '123-1-1-123-1234',
+    name: 'Jaime Lannister',
+    org_codes: ['org_1235', 'org_7890'],
+    picture: 'https://some-image.com',
+    provided_id: '1',
+    sub: 'kp:123456',
+    updated_at: 1683631328
+  };
 };
 
-export {idTokenStub};
+export {getIdTokenStub};

--- a/src/testData/idTokenStub.ts
+++ b/src/testData/idTokenStub.ts
@@ -1,13 +1,15 @@
+const nowInSeconds = Math.floor(Date.now() / 1000);
+
 const idTokenStub = {
   at_hash: '-p1234',
   aud: ['https://account.acme.com', '123456789'],
-  auth_time: 1683693508,
+  auth_time: nowInSeconds - 60,
   azp: '123456789',
   email: 'jaime@lannister.com',
-  exp: 1772323199,
+  exp: nowInSeconds + 60 * 60,
   family_name: 'Lannister',
   given_name: 'Jaime',
-  iat: 1683693508,
+  iat: nowInSeconds - 60,
   iss: 'https://account.acme.com',
   jti: '123-1-1-123-1234',
   name: 'Jaime Lannister',

--- a/src/testData/initializeStore.ts
+++ b/src/testData/initializeStore.ts
@@ -1,9 +1,9 @@
 import {store} from '../state/store';
-import {accessTokenStub} from './accessTokenStub';
-import {idTokenStub} from './idTokenStub';
+import {getAccessTokenStub} from './accessTokenStub';
+import {getIdTokenStub} from './idTokenStub';
 
 const initializeStore = () => {
-  store.setItem('kinde_access_token', accessTokenStub);
-  store.setItem('kinde_id_token', idTokenStub);
+  store.setItem('kinde_access_token', getAccessTokenStub());
+  store.setItem('kinde_id_token', getIdTokenStub());
 };
 export {initializeStore};

--- a/src/types.ts
+++ b/src/types.ts
@@ -95,11 +95,21 @@ export type OrgOptions = {
   app_state?: Record<string, unknown>;
 };
 
+export type AuthUrlParamValue =
+  | string
+  | number
+  | boolean
+  | bigint
+  | null
+  | undefined;
+
+export type AuthUrlParams = Record<string, AuthUrlParamValue>;
+
 export type AuthOptions = {
   org_code?: string;
   invitation_code?: string;
   app_state?: Record<string, unknown>;
-  authUrlParams?: object;
+  authUrlParams?: AuthUrlParams;
 };
 
 export type GetTokenOptions = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -97,6 +97,7 @@ export type OrgOptions = {
 
 export type AuthOptions = {
   org_code?: string;
+  invitation_code?: string;
   app_state?: Record<string, unknown>;
   authUrlParams?: object;
 };

--- a/src/utils/isJWTActive/isJWTActive.test.ts
+++ b/src/utils/isJWTActive/isJWTActive.test.ts
@@ -1,5 +1,5 @@
 import {initializeStore} from '../../testData/initializeStore';
-import {accessTokenStub} from '../../testData/accessTokenStub';
+import {getAccessTokenStub} from '../../testData/accessTokenStub';
 import type {JWT} from './isJWTActive.types';
 import {isJWTActive} from './isJWTActive';
 import {store} from '../../state/store';
@@ -8,7 +8,7 @@ describe('isJWTActive util', () => {
   beforeEach(() => initializeStore());
 
   test('returns false if provided token is expired', () => {
-    const expiredToken = {...accessTokenStub, exp: 949363200};
+    const expiredToken = {...getAccessTokenStub(), exp: 949363200};
     expect(isJWTActive(expiredToken)).toBe(false);
   });
 

--- a/src/utils/isTokenValid/isAccessTokenValid.test.ts
+++ b/src/utils/isTokenValid/isAccessTokenValid.test.ts
@@ -1,4 +1,4 @@
-import {getAccessTokenStub} from '../../testData/accessTokenStub';
+import {getAccessTokenStub as accessTokenStub} from '../../testData/accessTokenStub';
 import {isTokenValid} from './isTokenValid';
 
 const config = {
@@ -12,10 +12,8 @@ const header = {
   alg: 'RS256'
 };
 
-const accessTokenStub = () => getAccessTokenStub();
-
-describe('isIDToken valid', () => {
-  test('Throw error if token not provided', () => {
+describe('isAccessTokenValid', () => {
+  test('returns true for a valid access token', () => {
     expect(
       isTokenValid(
         {

--- a/src/utils/isTokenValid/isAccessTokenValid.test.ts
+++ b/src/utils/isTokenValid/isAccessTokenValid.test.ts
@@ -1,4 +1,4 @@
-import {accessTokenStub} from '../../testData/accessTokenStub';
+import {getAccessTokenStub} from '../../testData/accessTokenStub';
 import {isTokenValid} from './isTokenValid';
 
 const config = {
@@ -12,13 +12,15 @@ const header = {
   alg: 'RS256'
 };
 
+const accessTokenStub = () => getAccessTokenStub();
+
 describe('isIDToken valid', () => {
   test('Throw error if token not provided', () => {
     expect(
       isTokenValid(
         {
           header,
-          payload: {...accessTokenStub}
+          payload: accessTokenStub()
         },
         config
       )
@@ -30,7 +32,7 @@ describe('isIDToken valid', () => {
       isTokenValid(
         {
           header: {typ: 'blah', alg: 'HS256'},
-          payload: {...accessTokenStub}
+          payload: accessTokenStub()
         },
         config
       );
@@ -44,7 +46,7 @@ describe('isIDToken valid', () => {
       isTokenValid(
         {
           header,
-          payload: {...accessTokenStub, iss: null}
+          payload: {...accessTokenStub(), iss: null}
         },
         config
       );
@@ -56,7 +58,7 @@ describe('isIDToken valid', () => {
       isTokenValid(
         {
           header,
-          payload: {...accessTokenStub, iss: 'mate'}
+          payload: {...accessTokenStub(), iss: 'mate'}
         },
         config
       );
@@ -70,7 +72,7 @@ describe('isIDToken valid', () => {
       isTokenValid(
         {
           header,
-          payload: {...accessTokenStub, azp: null}
+          payload: {...accessTokenStub(), azp: null}
         },
         config
       );
@@ -82,7 +84,7 @@ describe('isIDToken valid', () => {
       isTokenValid(
         {
           header,
-          payload: {...accessTokenStub, azp: 'mate'}
+          payload: {...accessTokenStub(), azp: 'mate'}
         },
         config
       );
@@ -94,7 +96,7 @@ describe('isIDToken valid', () => {
       isTokenValid(
         {
           header,
-          payload: {...accessTokenStub, aud: 'mate'}
+          payload: {...accessTokenStub(), aud: 'mate'}
         },
         config
       );
@@ -106,7 +108,7 @@ describe('isIDToken valid', () => {
       isTokenValid(
         {
           header,
-          payload: {...accessTokenStub}
+          payload: accessTokenStub()
         },
         {...config, aud: undefined}
       )
@@ -118,7 +120,7 @@ describe('isIDToken valid', () => {
       isTokenValid(
         {
           header,
-          payload: {...accessTokenStub, aud: ['mate']}
+          payload: {...accessTokenStub(), aud: ['mate']}
         },
         config
       );
@@ -132,7 +134,7 @@ describe('isIDToken valid', () => {
       isTokenValid(
         {
           header,
-          payload: {...accessTokenStub, exp: 1683697108}
+          payload: {...accessTokenStub(), exp: 1683697108}
         },
         config
       );

--- a/src/utils/isTokenValid/isIDTokenValid.test.ts
+++ b/src/utils/isTokenValid/isIDTokenValid.test.ts
@@ -1,4 +1,4 @@
-import {idTokenStub} from '../../testData/idTokenStub';
+import {getIdTokenStub} from '../../testData/idTokenStub';
 import {isTokenValid} from './isTokenValid';
 
 const config = {
@@ -12,13 +12,15 @@ const header = {
   alg: 'RS256'
 };
 
+const idTokenStub = () => getIdTokenStub();
+
 describe('isIDToken valid', () => {
   test('Throw error if token not provided', () => {
     expect(
       isTokenValid(
         {
           header,
-          payload: {...idTokenStub}
+          payload: idTokenStub()
         },
         config
       )
@@ -30,7 +32,7 @@ describe('isIDToken valid', () => {
       isTokenValid(
         {
           header: {typ: 'blah', alg: 'HS256'},
-          payload: {...idTokenStub}
+          payload: idTokenStub()
         },
         config
       );
@@ -44,7 +46,7 @@ describe('isIDToken valid', () => {
       isTokenValid(
         {
           header,
-          payload: {...idTokenStub, iss: null}
+          payload: {...idTokenStub(), iss: null}
         },
         config
       );
@@ -56,7 +58,7 @@ describe('isIDToken valid', () => {
       isTokenValid(
         {
           header,
-          payload: {...idTokenStub, iss: 'mate'}
+          payload: {...idTokenStub(), iss: 'mate'}
         },
         config
       );
@@ -70,7 +72,7 @@ describe('isIDToken valid', () => {
       isTokenValid(
         {
           header,
-          payload: {...idTokenStub, azp: null}
+          payload: {...idTokenStub(), azp: null}
         },
         config
       );
@@ -82,7 +84,7 @@ describe('isIDToken valid', () => {
       isTokenValid(
         {
           header,
-          payload: {...idTokenStub, azp: 'mate'}
+          payload: {...idTokenStub(), azp: 'mate'}
         },
         config
       );
@@ -94,7 +96,7 @@ describe('isIDToken valid', () => {
       isTokenValid(
         {
           header,
-          payload: {...idTokenStub, aud: 'mate'}
+          payload: {...idTokenStub(), aud: 'mate'}
         },
         config
       );
@@ -106,7 +108,7 @@ describe('isIDToken valid', () => {
       isTokenValid(
         {
           header,
-          payload: {...idTokenStub, aud: ['mate']}
+          payload: {...idTokenStub(), aud: ['mate']}
         },
         config
       );
@@ -121,7 +123,7 @@ describe('isIDToken valid', () => {
         {
           header,
           payload: {
-            ...idTokenStub,
+            ...idTokenStub(),
             aud: ['https://account.acme.com', '123456789']
           }
         },
@@ -135,7 +137,7 @@ describe('isIDToken valid', () => {
       isTokenValid(
         {
           header,
-          payload: {...idTokenStub, exp: 1683697108}
+          payload: {...idTokenStub(), exp: 1683697108}
         },
         config
       );

--- a/src/utils/isTokenValid/isIDTokenValid.test.ts
+++ b/src/utils/isTokenValid/isIDTokenValid.test.ts
@@ -1,4 +1,4 @@
-import {getIdTokenStub} from '../../testData/idTokenStub';
+import {getIdTokenStub as idTokenStub} from '../../testData/idTokenStub';
 import {isTokenValid} from './isTokenValid';
 
 const config = {
@@ -12,10 +12,8 @@ const header = {
   alg: 'RS256'
 };
 
-const idTokenStub = () => getIdTokenStub();
-
 describe('isIDToken valid', () => {
-  test('Throw error if token not provided', () => {
+  test('returns true for a valid ID token', () => {
     expect(
       isTokenValid(
         {


### PR DESCRIPTION
Introduce invitation handling in the createKindeClient function, allowing users to start an authentication flow using an invitation code from the URL. Update related types and ensure invitation parameters are correctly passed during login. There were also a couple on already failing tests that I had to fix otherwise I could not make a commit due to a husky rule.

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._

