### PR TITLE
Fix/multi tab token syncing

### DIFF
--- a/src/createKindeClient.test.ts
+++ b/src/createKindeClient.test.ts
@@ -125,6 +125,7 @@ describe('createKindeClient invitation flow', () => {
   });
 
   afterEach(() => {
+    storageSettings.onRefreshHandler = undefined;
     jest.clearAllMocks();
   });
 
@@ -213,6 +214,7 @@ describe('refresh token storage routing (expired access → refresh recovery)', 
   });
 
   afterEach(() => {
+    storageSettings.onRefreshHandler = undefined;
     jest.clearAllMocks();
   });
 
@@ -329,6 +331,7 @@ describe('on_redirect_callback semantics', () => {
   });
 
   afterEach(() => {
+    storageSettings.onRefreshHandler = undefined;
     jest.clearAllMocks();
   });
 
@@ -396,6 +399,7 @@ describe('on_session_restore_callback semantics', () => {
   });
 
   afterEach(() => {
+    storageSettings.onRefreshHandler = undefined;
     jest.clearAllMocks();
   });
 
@@ -462,6 +466,7 @@ describe('legacy localStorage refresh key migration', () => {
   });
 
   afterEach(() => {
+    storageSettings.onRefreshHandler = undefined;
     jest.clearAllMocks();
   });
 

--- a/src/createKindeClient.ts
+++ b/src/createKindeClient.ts
@@ -13,6 +13,7 @@ import {
   isTokenValid
 } from './utils/index';
 import {store} from './state/store';
+import {createTabSync, tokensFromRefreshResult} from './state/tabSync';
 import type {
   AuthOptions,
   KindeClient,
@@ -41,6 +42,8 @@ import {
   getUserProfile as getUserProfileFromJsUtils,
   LocalStorage,
   checkAuth,
+  refreshToken,
+  RefreshType,
   setInsecureStorage,
   storageSettings,
   LoginMethodParams,
@@ -192,6 +195,112 @@ const createKindeClient = async (
   // which is inaccessible from localhost, causing a forced re-login on every page load.
   storageSettings.useInsecureForRefreshToken = isUseLocalStorage;
 
+  const tabSync = createTabSync({
+    store,
+    insecureStorage: localStorageAdapter,
+    useInsecureForRefreshToken: isUseLocalStorage
+  });
+
+  const runJsUtilsRefresh = async (
+    refreshType: RefreshType = RefreshType.refreshToken
+  ): Promise<RefreshTokenResult> => {
+    const savedHandler = storageSettings.onRefreshHandler;
+    storageSettings.onRefreshHandler = undefined;
+    try {
+      return await refreshToken({
+        domain,
+        clientId: client_id,
+        refreshType
+      });
+    } finally {
+      storageSettings.onRefreshHandler = savedHandler;
+    }
+  };
+
+  const runRefreshWithTabSync = async (
+    refreshType: RefreshType = RefreshType.refreshToken
+  ): Promise<RefreshTokenResult> => {
+    const lock = await tabSync.tryWithRefreshLock(() =>
+      runJsUtilsRefresh(refreshType)
+    );
+
+    if (lock.ran) {
+      if (lock.value.success) {
+        await tabSync.applyTokensFromResult(lock.value);
+        const tokens = tokensFromRefreshResult(lock.value);
+        if (tokens) {
+          tabSync.broadcastTokens(tokens);
+        }
+      }
+      return lock.value;
+    }
+
+    const tokens = await tabSync.waitForTokenBroadcast();
+    if (tokens) {
+      return {
+        success: true,
+        [StorageKeys.accessToken]: tokens.accessToken,
+        [StorageKeys.idToken]: tokens.idToken,
+        ...(tokens.refreshToken
+          ? {[StorageKeys.refreshToken]: tokens.refreshToken}
+          : {})
+      };
+    }
+
+    return {
+      success: false,
+      error: 'Token refresh in progress in another tab'
+    };
+  };
+
+  storageSettings.onRefreshHandler = (refreshType) =>
+    runRefreshWithTabSync(refreshType);
+
+  const runCheckAuthWithTabSync = async (): Promise<RefreshTokenResult> => {
+    const lock = await tabSync.tryWithRefreshLock(async () => {
+      const savedHandler = storageSettings.onRefreshHandler;
+      storageSettings.onRefreshHandler = undefined;
+      try {
+        return await checkAuth({domain, clientId: client_id});
+      } finally {
+        storageSettings.onRefreshHandler = savedHandler;
+      }
+    });
+
+    if (lock.ran) {
+      if (lock.value.success) {
+        await tabSync.applyTokensFromResult(lock.value);
+        const tokens = tokensFromRefreshResult(lock.value);
+        if (tokens) {
+          tabSync.broadcastTokens(tokens);
+        }
+      }
+      return lock.value;
+    }
+
+    const tokens = await tabSync.waitForTokenBroadcast();
+    if (tokens) {
+      return {
+        success: true,
+        [StorageKeys.accessToken]: tokens.accessToken,
+        [StorageKeys.idToken]: tokens.idToken,
+        ...(tokens.refreshToken
+          ? {[StorageKeys.refreshToken]: tokens.refreshToken}
+          : {})
+      };
+    }
+
+    return {
+      success: false,
+      error: 'Authentication check in progress in another tab'
+    };
+  };
+
+  tabSync.setupListeners({});
+  tabSync.setupVisibilitySync(() => {
+    void runCheckAuthWithTabSync();
+  });
+
   const config = {
     audience,
     client_id,
@@ -243,7 +352,10 @@ const createKindeClient = async (
     {tokenType} = {tokenType: storageMap.access_token}
   ) => {
     const localStorageRefreshToken = isUseLocalStorage
-      ? (localStorage.getItem(storageMap.refresh_token) as string)
+      ? (localStorageAdapter.getSessionItem(
+          StorageKeys.refreshToken
+        ) as string) ||
+        (localStorage.getItem(storageMap.refresh_token) as string)
       : (store.getItem(storageMap.refresh_token) as string);
 
     const isCallTokenEndpoint =
@@ -273,6 +385,17 @@ const createKindeClient = async (
         const data = await response.json();
 
         setStore(data);
+
+        const tokens = tokensFromRefreshResult({
+          success: true,
+          [StorageKeys.accessToken]: data.access_token,
+          [StorageKeys.idToken]: data.id_token,
+          [StorageKeys.refreshToken]: data.refresh_token
+        });
+        if (tokens) {
+          void tabSync.applyTokens(tokens);
+          tabSync.broadcastTokens(tokens);
+        }
 
         if (tokenType === storageMap.id_token) {
           return data.id_token;
@@ -561,6 +684,12 @@ const createKindeClient = async (
       });
 
       if (codeResponse.success) {
+        await tabSync.applyTokensFromResult(codeResponse);
+        const syncedTokens = tokensFromRefreshResult(codeResponse);
+        if (syncedTokens) {
+          tabSync.broadcastTokens(syncedTokens);
+        }
+
         const user = await getUserProfile();
         if (user) {
           on_redirect_callback?.(user, storedAppState);
@@ -674,6 +803,8 @@ const createKindeClient = async (
         )
       ]);
 
+      tabSync.broadcastSessionCleared();
+
       try {
         await navigateToKinde({
           url: `${domain}/logout?${params.toString()}`
@@ -743,8 +874,10 @@ const createKindeClient = async (
     try {
       try {
         migrateLegacyRefreshTokenKey();
-        // This handles the refresh token
-        await checkAuth({domain, clientId: client_id});
+        // Restores session and refreshes near-expiry tokens via js-utils checkAuth.
+        // On custom domains, refresh uses the httpOnly _kbrte cookie (credentials: include);
+        // the refresh_token field is intentionally omitted from the POST body.
+        await runCheckAuthWithTabSync();
       } catch (err) {
         console.warn('checkAuth failed:', err);
         on_error_callback?.({

--- a/src/createKindeClient.ts
+++ b/src/createKindeClient.ts
@@ -276,7 +276,15 @@ const createKindeClient = async (
 
   tabSync.setupListeners({});
   tabSync.setupVisibilitySync(() => {
-    void runCheckAuthWithTabSync();
+    void runCheckAuthWithTabSync().catch((error) => {
+      console.warn('checkAuth failed:', error);
+      on_error_callback?.({
+        error: 'ERR_CHECK_AUTH',
+        errorDescription: String(error),
+        state: '',
+        appState: {}
+      });
+    });
   });
 
   const config = {
@@ -362,7 +370,7 @@ const createKindeClient = async (
 
         const data = await response.json();
 
-        setStore(data);
+        const stored = setStore(data);
 
         const tokens = tokensFromRefreshResult({
           success: true,
@@ -370,7 +378,7 @@ const createKindeClient = async (
           [StorageKeys.idToken]: data.id_token,
           [StorageKeys.refreshToken]: data.refresh_token
         });
-        if (tokens) {
+        if (stored && tokens) {
           void tabSync.applyTokens(tokens);
           tabSync.broadcastTokens(tokens);
         }
@@ -388,7 +396,7 @@ const createKindeClient = async (
 
   /* @deprecated only used for old getToken method which is now deprecated */
   const setStore = (data: KindeStateTokenBundle & {error: string}) => {
-    if (!data || data.error) return;
+    if (!data || data.error) return false;
 
     const idToken = jwtDecode(data.id_token)! as JWT & KindeUser;
     const idTokenHeader = jwtDecode(data.id_token, {header: true});
@@ -434,7 +442,9 @@ const createKindeClient = async (
       } else {
         store.setItem(storageMap.refresh_token, data.refresh_token);
       }
+      return true;
     }
+    return false;
   };
 
   const readLegacyRawToken = (

--- a/src/createKindeClient.ts
+++ b/src/createKindeClient.ts
@@ -223,8 +223,7 @@ const createKindeClient = async (
 
   const withTabSyncCoordination = async (
     operation: () => Promise<RefreshTokenResult>,
-    inProgressErrorMessage: string,
-    options?: {fallbackToBroadcastOnFailedLock?: boolean}
+    inProgressErrorMessage: string
   ): Promise<RefreshTokenResult> => {
     const lock = await tabSync.tryWithRefreshLock(operation);
 
@@ -238,11 +237,10 @@ const createKindeClient = async (
     }
 
     const waitForPeerTokens =
-      !lock.ran ||
-      (lock.ran && options?.fallbackToBroadcastOnFailedLock === true);
+      !lock.ran || (lock.ran && lock.usedAmbiguousFallback);
 
     if (waitForPeerTokens) {
-      // Lost the lock, or won the LS lock but refresh failed (e.g. token already used by another tab)
+      // Another tab holds the lock, or LS lock outcome was ambiguous and refresh failed
       const tokens = await tabSync.waitForTokenBroadcast();
       if (tokens) {
         await tabSync.applyTokens(tokens);
@@ -272,8 +270,7 @@ const createKindeClient = async (
   ) =>
     withTabSyncCoordination(
       () => runJsUtilsRefresh(refreshType),
-      'Token refresh in progress in another tab',
-      {fallbackToBroadcastOnFailedLock: true}
+      'Token refresh in progress in another tab'
     );
 
   storageSettings.onRefreshHandler = (refreshType) =>

--- a/src/createKindeClient.ts
+++ b/src/createKindeClient.ts
@@ -217,12 +217,11 @@ const createKindeClient = async (
     }
   };
 
-  const runRefreshWithTabSync = async (
-    refreshType: RefreshType = RefreshType.refreshToken
+  const withTabSyncCoordination = async (
+    operation: () => Promise<RefreshTokenResult>,
+    inProgressErrorMessage: string
   ): Promise<RefreshTokenResult> => {
-    const lock = await tabSync.tryWithRefreshLock(() =>
-      runJsUtilsRefresh(refreshType)
-    );
+    const lock = await tabSync.tryWithRefreshLock(operation);
 
     if (lock.ran) {
       if (lock.value.success) {
@@ -249,15 +248,23 @@ const createKindeClient = async (
 
     return {
       success: false,
-      error: 'Token refresh in progress in another tab'
+      error: inProgressErrorMessage
     };
   };
+
+  const runRefreshWithTabSync = (
+    refreshType: RefreshType = RefreshType.refreshToken
+  ) =>
+    withTabSyncCoordination(
+      () => runJsUtilsRefresh(refreshType),
+      'Token refresh in progress in another tab'
+    );
 
   storageSettings.onRefreshHandler = (refreshType) =>
     runRefreshWithTabSync(refreshType);
 
-  const runCheckAuthWithTabSync = async (): Promise<RefreshTokenResult> => {
-    const lock = await tabSync.tryWithRefreshLock(async () => {
+  const runCheckAuthWithTabSync = () =>
+    withTabSyncCoordination(async () => {
       const savedHandler = storageSettings.onRefreshHandler;
       storageSettings.onRefreshHandler = undefined;
       try {
@@ -265,36 +272,7 @@ const createKindeClient = async (
       } finally {
         storageSettings.onRefreshHandler = savedHandler;
       }
-    });
-
-    if (lock.ran) {
-      if (lock.value.success) {
-        await tabSync.applyTokensFromResult(lock.value);
-        const tokens = tokensFromRefreshResult(lock.value);
-        if (tokens) {
-          tabSync.broadcastTokens(tokens);
-        }
-      }
-      return lock.value;
-    }
-
-    const tokens = await tabSync.waitForTokenBroadcast();
-    if (tokens) {
-      return {
-        success: true,
-        [StorageKeys.accessToken]: tokens.accessToken,
-        [StorageKeys.idToken]: tokens.idToken,
-        ...(tokens.refreshToken
-          ? {[StorageKeys.refreshToken]: tokens.refreshToken}
-          : {})
-      };
-    }
-
-    return {
-      success: false,
-      error: 'Authentication check in progress in another tab'
-    };
-  };
+    }, 'Authentication check in progress in another tab');
 
   tabSync.setupListeners({});
   tabSync.setupVisibilitySync(() => {

--- a/src/createKindeClient.ts
+++ b/src/createKindeClient.ts
@@ -13,7 +13,11 @@ import {
   isTokenValid
 } from './utils/index';
 import {store} from './state/store';
-import {createTabSync, tokensFromRefreshResult} from './state/tabSync';
+import {
+  createTabSync,
+  isSuccessResult,
+  tokensFromRefreshResult
+} from './state/tabSync';
 import type {
   AuthOptions,
   KindeClient,
@@ -219,31 +223,42 @@ const createKindeClient = async (
 
   const withTabSyncCoordination = async (
     operation: () => Promise<RefreshTokenResult>,
-    inProgressErrorMessage: string
+    inProgressErrorMessage: string,
+    options?: {fallbackToBroadcastOnFailedLock?: boolean}
   ): Promise<RefreshTokenResult> => {
     const lock = await tabSync.tryWithRefreshLock(operation);
 
-    if (lock.ran) {
-      if (lock.value.success) {
-        await tabSync.applyTokensFromResult(lock.value);
-        const tokens = tokensFromRefreshResult(lock.value);
-        if (tokens) {
-          tabSync.broadcastTokens(tokens);
-        }
+    if (lock.ran && isSuccessResult(lock.value)) {
+      await tabSync.applyTokensFromResult(lock.value);
+      const tokens = tokensFromRefreshResult(lock.value);
+      if (tokens) {
+        tabSync.broadcastTokens(tokens);
       }
       return lock.value;
     }
 
-    const tokens = await tabSync.waitForTokenBroadcast();
-    if (tokens) {
-      return {
-        success: true,
-        [StorageKeys.accessToken]: tokens.accessToken,
-        [StorageKeys.idToken]: tokens.idToken,
-        ...(tokens.refreshToken
-          ? {[StorageKeys.refreshToken]: tokens.refreshToken}
-          : {})
-      };
+    const waitForPeerTokens =
+      !lock.ran ||
+      (lock.ran && options?.fallbackToBroadcastOnFailedLock === true);
+
+    if (waitForPeerTokens) {
+      // Lost the lock, or won the LS lock but refresh failed (e.g. token already used by another tab)
+      const tokens = await tabSync.waitForTokenBroadcast();
+      if (tokens) {
+        await tabSync.applyTokens(tokens);
+        return {
+          success: true,
+          [StorageKeys.accessToken]: tokens.accessToken,
+          [StorageKeys.idToken]: tokens.idToken,
+          ...(tokens.refreshToken
+            ? {[StorageKeys.refreshToken]: tokens.refreshToken}
+            : {})
+        };
+      }
+    }
+
+    if (lock.ran) {
+      return lock.value;
     }
 
     return {
@@ -257,7 +272,8 @@ const createKindeClient = async (
   ) =>
     withTabSyncCoordination(
       () => runJsUtilsRefresh(refreshType),
-      'Token refresh in progress in another tab'
+      'Token refresh in progress in another tab',
+      {fallbackToBroadcastOnFailedLock: true}
     );
 
   storageSettings.onRefreshHandler = (refreshType) =>

--- a/src/state/tabSync.test.ts
+++ b/src/state/tabSync.test.ts
@@ -378,6 +378,48 @@ describe('tabSync', () => {
     expect(onVisible).toHaveBeenCalled();
   });
 
+  test('waitForTokenBroadcast resolves when applyTokens fails on tokens_updated', async () => {
+    const consoleError = jest
+      .spyOn(console, 'error')
+      .mockImplementation(jest.fn());
+    const failingStore = {
+      ...store,
+      setItems: jest.fn().mockRejectedValue(new Error('storage full'))
+    };
+    const tabSync = createTrackedTabSync({store: failingStore});
+    const onTokensUpdated = jest.fn();
+
+    tabSync.setupListeners({onTokensUpdated});
+
+    const waitPromise = tabSync.waitForTokenBroadcast(5000);
+
+    const message = {
+      type: 'tokens_updated' as const,
+      tabId: 'other-tab-id',
+      tokens: SAMPLE_TOKENS
+    };
+
+    const storageHandler = (
+      window.addEventListener as jest.Mock
+    ).mock.calls.find(([event]) => event === 'storage')?.[1] as
+      | ((event: StorageEvent) => void)
+      | undefined;
+
+    storageHandler?.({
+      key: 'kinde_token_sync',
+      newValue: JSON.stringify(message)
+    } as StorageEvent);
+
+    await expect(waitPromise).resolves.toEqual(SAMPLE_TOKENS);
+    expect(onTokensUpdated).not.toHaveBeenCalled();
+    expect(consoleError).toHaveBeenCalledWith(
+      'Failed to apply synced tokens:',
+      expect.any(Error)
+    );
+
+    consoleError.mockRestore();
+  });
+
   test('waitForTokenBroadcast resolves when a storage event delivers tokens', async () => {
     const tabSync = createTrackedTabSync({store});
     tabSync.setupListeners({});

--- a/src/state/tabSync.test.ts
+++ b/src/state/tabSync.test.ts
@@ -1,0 +1,241 @@
+import {StorageKeys} from '../kindeUtils';
+import {store} from './store';
+import {
+  createTabSync,
+  tokensFromRefreshResult,
+  type TabSyncTokens
+} from './tabSync';
+
+const SAMPLE_TOKENS: TabSyncTokens = {
+  accessToken: 'access-jwt',
+  idToken: 'id-jwt',
+  refreshToken: 'refresh-value'
+};
+
+const makeStorageMock = () => {
+  const data: Record<string, string> = {};
+  return {
+    getItem: (key: string) => data[key] ?? null,
+    setItem: (key: string, value: string) => {
+      data[key] = value;
+    },
+    removeItem: (key: string) => {
+      delete data[key];
+    },
+    clear: () => {
+      Object.keys(data).forEach((key) => delete data[key]);
+    }
+  };
+};
+
+describe('tabSync', () => {
+  beforeEach(() => {
+    store.reset();
+
+    const local = makeStorageMock();
+    const session = makeStorageMock();
+
+    Object.defineProperty(global, 'localStorage', {
+      value: local,
+      writable: true,
+      configurable: true
+    });
+    Object.defineProperty(global, 'sessionStorage', {
+      value: session,
+      writable: true,
+      configurable: true
+    });
+    Object.defineProperty(global, 'window', {
+      value: {
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+        setTimeout: (...args: Parameters<typeof setTimeout>) =>
+          setTimeout(...args),
+        clearTimeout: (...args: Parameters<typeof clearTimeout>) =>
+          clearTimeout(...args)
+      },
+      writable: true,
+      configurable: true
+    });
+    Object.defineProperty(global, 'document', {
+      value: {
+        visibilityState: 'visible',
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn()
+      },
+      writable: true,
+      configurable: true
+    });
+  });
+
+  test('applyTokens writes access, id, and refresh to the store', async () => {
+    const tabSync = createTabSync({store});
+
+    await tabSync.applyTokens(SAMPLE_TOKENS);
+
+    expect(store.getSessionItem(StorageKeys.accessToken)).toBe('access-jwt');
+    expect(store.getSessionItem(StorageKeys.idToken)).toBe('id-jwt');
+    expect(store.getSessionItem(StorageKeys.refreshToken)).toBe(
+      'refresh-value'
+    );
+  });
+
+  test('tokensFromRefreshResult maps a successful js-utils result', () => {
+    const tokens = tokensFromRefreshResult({
+      success: true,
+      [StorageKeys.accessToken]: 'at',
+      [StorageKeys.idToken]: 'it',
+      [StorageKeys.refreshToken]: 'rt'
+    });
+
+    expect(tokens).toEqual({
+      accessToken: 'at',
+      idToken: 'it',
+      refreshToken: 'rt'
+    });
+  });
+
+  test('tryWithRefreshLock runs the callback when the lock is available', async () => {
+    const tabSync = createTabSync({store});
+    const fn = jest.fn().mockResolvedValue('ok');
+
+    const result = await tabSync.tryWithRefreshLock(fn);
+
+    expect(result).toEqual({ran: true, value: 'ok'});
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  test('tryWithRefreshLock skips when a localStorage lock is held by another tab', async () => {
+    const originalLocks = navigator.locks;
+    Object.defineProperty(navigator, 'locks', {
+      value: undefined,
+      configurable: true
+    });
+
+    try {
+      const tabSync = createTabSync({store});
+      localStorage.setItem(
+        'kinde_refresh_lock',
+        JSON.stringify({
+          tabId: 'other-tab',
+          until: Date.now() + 60_000
+        })
+      );
+
+      const fn = jest.fn().mockResolvedValue('ok');
+      const result = await tabSync.tryWithRefreshLock(fn);
+
+      expect(result).toEqual({ran: false});
+      expect(fn).not.toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(navigator, 'locks', {
+        value: originalLocks,
+        configurable: true
+      });
+    }
+  });
+
+  test('setupListeners applies tokens via localStorage storage event fallback', async () => {
+    const tabSync = createTabSync({store});
+    const onTokensUpdated = jest.fn();
+
+    tabSync.setupListeners({onTokensUpdated});
+
+    const message = {
+      type: 'tokens_updated' as const,
+      tabId: 'other-tab-id',
+      tokens: SAMPLE_TOKENS
+    };
+    localStorage.setItem('kinde_token_sync', JSON.stringify(message));
+
+    const storageHandler = (
+      window.addEventListener as jest.Mock
+    ).mock.calls.find(([event]) => event === 'storage')?.[1] as
+      | ((event: StorageEvent) => void)
+      | undefined;
+
+    storageHandler?.({
+      key: 'kinde_token_sync',
+      newValue: JSON.stringify(message)
+    } as StorageEvent);
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(store.getSessionItem(StorageKeys.accessToken)).toBe('access-jwt');
+    expect(onTokensUpdated).toHaveBeenCalledWith(SAMPLE_TOKENS);
+  });
+
+  test('setupListeners clears the store on session_cleared via storage event', async () => {
+    store.setSessionItem(StorageKeys.accessToken, 'existing');
+    const tabSync = createTabSync({store});
+    const onSessionCleared = jest.fn();
+
+    tabSync.setupListeners({onSessionCleared});
+
+    const message = {
+      type: 'session_cleared' as const,
+      tabId: 'other-tab-id'
+    };
+
+    const storageHandler = (
+      window.addEventListener as jest.Mock
+    ).mock.calls.find(([event]) => event === 'storage')?.[1] as
+      | ((event: StorageEvent) => void)
+      | undefined;
+
+    storageHandler?.({
+      key: 'kinde_token_sync',
+      newValue: JSON.stringify(message)
+    } as StorageEvent);
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(store.getSessionItem(StorageKeys.accessToken)).toBeNull();
+    expect(onSessionCleared).toHaveBeenCalled();
+  });
+
+  test('setupVisibilitySync invokes callback when the document becomes visible', () => {
+    const tabSync = createTabSync({store});
+    const onVisible = jest.fn();
+
+    tabSync.setupVisibilitySync(onVisible);
+
+    const visibilityHandler = (
+      document.addEventListener as jest.Mock
+    ).mock.calls.find(([event]) => event === 'visibilitychange')?.[1] as
+      | (() => void)
+      | undefined;
+
+    visibilityHandler?.();
+
+    expect(onVisible).toHaveBeenCalled();
+  });
+
+  test('waitForTokenBroadcast resolves when a storage event delivers tokens', async () => {
+    const tabSync = createTabSync({store});
+    tabSync.setupListeners({});
+
+    const waitPromise = tabSync.waitForTokenBroadcast(5000);
+
+    const message = {
+      type: 'tokens_updated' as const,
+      tabId: 'other-tab-id',
+      tokens: SAMPLE_TOKENS
+    };
+
+    const storageHandler = (
+      window.addEventListener as jest.Mock
+    ).mock.calls.find(([event]) => event === 'storage')?.[1] as
+      | ((event: StorageEvent) => void)
+      | undefined;
+
+    storageHandler?.({
+      key: 'kinde_token_sync',
+      newValue: JSON.stringify(message)
+    } as StorageEvent);
+
+    await expect(waitPromise).resolves.toEqual(SAMPLE_TOKENS);
+  });
+});

--- a/src/state/tabSync.test.ts
+++ b/src/state/tabSync.test.ts
@@ -161,8 +161,47 @@ describe('tabSync', () => {
 
     const result = await tabSync.tryWithRefreshLock(fn);
 
-    expect(result).toEqual({ran: true, value: 'ok'});
+    expect(result).toEqual({
+      ran: true,
+      value: 'ok',
+      usedAmbiguousFallback: true
+    });
     expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  test('tryWithRefreshLock uses Web Locks without ambiguous fallback when available', async () => {
+    const originalLocks = navigator.locks;
+    const request = jest.fn(
+      async (
+        _name: string,
+        _options: {ifAvailable: boolean},
+        callback: (lock: object) => Promise<void>
+      ) => {
+        await callback({});
+      }
+    );
+    Object.defineProperty(navigator, 'locks', {
+      value: {request},
+      configurable: true
+    });
+
+    try {
+      const tabSync = createTrackedTabSync({store});
+      const fn = jest.fn().mockResolvedValue('ok');
+      const result = await tabSync.tryWithRefreshLock(fn);
+
+      expect(result).toEqual({
+        ran: true,
+        value: 'ok',
+        usedAmbiguousFallback: false
+      });
+      expect(request).toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(navigator, 'locks', {
+        value: originalLocks,
+        configurable: true
+      });
+    }
   });
 
   test('tryWithRefreshLock skips when a localStorage lock is held by another tab', async () => {

--- a/src/state/tabSync.test.ts
+++ b/src/state/tabSync.test.ts
@@ -98,6 +98,21 @@ describe('tabSync', () => {
     disposers.length = 0;
   });
 
+  test('tabId is generated when sessionStorage throws', () => {
+    const session = sessionStorage as ReturnType<typeof makeStorageMock>;
+    session.getItem = () => {
+      throw new Error('sessionStorage disabled');
+    };
+    session.setItem = () => {
+      throw new Error('sessionStorage disabled');
+    };
+
+    const tabSync = createTrackedTabSync({store});
+
+    expect(tabSync.tabId).toBeTruthy();
+    expect(tabSync.tabId).not.toBe('server');
+  });
+
   test('applyTokens writes access, id, and refresh to the store', async () => {
     const tabSync = createTrackedTabSync({store});
 

--- a/src/state/tabSync.test.ts
+++ b/src/state/tabSync.test.ts
@@ -3,6 +3,8 @@ import {store} from './store';
 import {
   createTabSync,
   tokensFromRefreshResult,
+  type TabSync,
+  type TabSyncOptions,
   type TabSyncTokens
 } from './tabSync';
 
@@ -29,8 +31,22 @@ const makeStorageMock = () => {
 };
 
 describe('tabSync', () => {
+  const disposers: Array<() => void> = [];
+
+  const createTrackedTabSync = (options: TabSyncOptions): TabSync => {
+    const tabSync = createTabSync(options);
+    disposers.push(() => tabSync.dispose());
+    return tabSync;
+  };
+
   beforeEach(() => {
     store.reset();
+
+    Object.defineProperty(global, 'BroadcastChannel', {
+      value: undefined,
+      writable: true,
+      configurable: true
+    });
 
     const local = makeStorageMock();
     const session = makeStorageMock();
@@ -70,8 +86,13 @@ describe('tabSync', () => {
     });
   });
 
+  afterEach(() => {
+    disposers.forEach((dispose) => dispose());
+    disposers.length = 0;
+  });
+
   test('applyTokens writes access, id, and refresh to the store', async () => {
-    const tabSync = createTabSync({store});
+    const tabSync = createTrackedTabSync({store});
 
     await tabSync.applyTokens(SAMPLE_TOKENS);
 
@@ -97,8 +118,23 @@ describe('tabSync', () => {
     });
   });
 
+  test('applyTokensFromResult and tokensFromRefreshResult skip when idToken is missing', async () => {
+    const tabSync = createTrackedTabSync({store});
+    const result = {
+      success: true as const,
+      [StorageKeys.accessToken]: 'at-only'
+    };
+
+    expect(tokensFromRefreshResult(result)).toBeNull();
+
+    await tabSync.applyTokensFromResult(result);
+
+    expect(store.getSessionItem(StorageKeys.accessToken)).toBeNull();
+    expect(store.getSessionItem(StorageKeys.idToken)).toBeNull();
+  });
+
   test('tryWithRefreshLock runs the callback when the lock is available', async () => {
-    const tabSync = createTabSync({store});
+    const tabSync = createTrackedTabSync({store});
     const fn = jest.fn().mockResolvedValue('ok');
 
     const result = await tabSync.tryWithRefreshLock(fn);
@@ -115,7 +151,7 @@ describe('tabSync', () => {
     });
 
     try {
-      const tabSync = createTabSync({store});
+      const tabSync = createTrackedTabSync({store});
       localStorage.setItem(
         'kinde_refresh_lock',
         JSON.stringify({
@@ -138,7 +174,7 @@ describe('tabSync', () => {
   });
 
   test('setupListeners applies tokens via localStorage storage event fallback', async () => {
-    const tabSync = createTabSync({store});
+    const tabSync = createTrackedTabSync({store});
     const onTokensUpdated = jest.fn();
 
     tabSync.setupListeners({onTokensUpdated});
@@ -169,7 +205,7 @@ describe('tabSync', () => {
 
   test('setupListeners clears the store on session_cleared via storage event', async () => {
     store.setSessionItem(StorageKeys.accessToken, 'existing');
-    const tabSync = createTabSync({store});
+    const tabSync = createTrackedTabSync({store});
     const onSessionCleared = jest.fn();
 
     tabSync.setupListeners({onSessionCleared});
@@ -197,7 +233,7 @@ describe('tabSync', () => {
   });
 
   test('setupVisibilitySync invokes callback when the document becomes visible', () => {
-    const tabSync = createTabSync({store});
+    const tabSync = createTrackedTabSync({store});
     const onVisible = jest.fn();
 
     tabSync.setupVisibilitySync(onVisible);
@@ -214,7 +250,7 @@ describe('tabSync', () => {
   });
 
   test('waitForTokenBroadcast resolves when a storage event delivers tokens', async () => {
-    const tabSync = createTabSync({store});
+    const tabSync = createTrackedTabSync({store});
     tabSync.setupListeners({});
 
     const waitPromise = tabSync.waitForTokenBroadcast(5000);

--- a/src/state/tabSync.test.ts
+++ b/src/state/tabSync.test.ts
@@ -435,14 +435,16 @@ describe('tabSync', () => {
       newValue: JSON.stringify(message)
     } as StorageEvent);
 
-    await expect(waitPromise).resolves.toEqual(SAMPLE_TOKENS);
-    expect(onTokensUpdated).not.toHaveBeenCalled();
-    expect(consoleError).toHaveBeenCalledWith(
-      'Failed to apply synced tokens:',
-      expect.any(Error)
-    );
-
-    consoleError.mockRestore();
+    try {
+      await expect(waitPromise).resolves.toEqual(SAMPLE_TOKENS);
+      expect(onTokensUpdated).not.toHaveBeenCalled();
+      expect(consoleError).toHaveBeenCalledWith(
+        'Failed to apply synced tokens:',
+        expect.any(Error)
+      );
+    } finally {
+      consoleError.mockRestore();
+    }
   });
 
   test('waitForTokenBroadcast resolves when a storage event delivers tokens', async () => {

--- a/src/state/tabSync.test.ts
+++ b/src/state/tabSync.test.ts
@@ -361,7 +361,7 @@ describe('tabSync', () => {
     expect(removeSessionItem).toHaveBeenCalledWith(StorageKeys.refreshToken);
   });
 
-  test('setupVisibilitySync invokes callback when the document becomes visible', () => {
+  test('setupVisibilitySync invokes callback when the document becomes visible', async () => {
     const tabSync = createTrackedTabSync({store});
     const onVisible = jest.fn();
 
@@ -375,7 +375,32 @@ describe('tabSync', () => {
 
     visibilityHandler?.();
 
-    expect(onVisible).toHaveBeenCalled();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(onVisible).toHaveBeenCalledTimes(1);
+  });
+
+  test('setupVisibilitySync deduplicates visibilitychange and focus in the same tick', async () => {
+    const tabSync = createTrackedTabSync({store});
+    const onVisible = jest.fn();
+
+    tabSync.setupVisibilitySync(onVisible);
+
+    const visibilityHandler = (
+      document.addEventListener as jest.Mock
+    ).mock.calls.find(([event]) => event === 'visibilitychange')?.[1] as
+      | (() => void)
+      | undefined;
+    const focusHandler = (window.addEventListener as jest.Mock).mock.calls.find(
+      ([event]) => event === 'focus'
+    )?.[1] as (() => void) | undefined;
+
+    visibilityHandler?.();
+    focusHandler?.();
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(onVisible).toHaveBeenCalledTimes(1);
   });
 
   test('waitForTokenBroadcast resolves when applyTokens fails on tokens_updated', async () => {

--- a/src/state/tabSync.test.ts
+++ b/src/state/tabSync.test.ts
@@ -84,6 +84,13 @@ describe('tabSync', () => {
       writable: true,
       configurable: true
     });
+    Object.defineProperty(global, 'navigator', {
+      value: {
+        locks: undefined
+      },
+      writable: true,
+      configurable: true
+    });
   });
 
   afterEach(() => {
@@ -173,6 +180,43 @@ describe('tabSync', () => {
     }
   });
 
+  test('tryWithRefreshLock skips when localStorage lock is lost after write', async () => {
+    const originalLocks = navigator.locks;
+    Object.defineProperty(navigator, 'locks', {
+      value: undefined,
+      configurable: true
+    });
+
+    const local = localStorage as ReturnType<typeof makeStorageMock>;
+    const originalSetItem = local.setItem.bind(local);
+    local.setItem = (key: string, value: string) => {
+      originalSetItem(key, value);
+      if (key === 'kinde_refresh_lock') {
+        originalSetItem(
+          key,
+          JSON.stringify({
+            tabId: 'other-tab',
+            until: Date.now() + 60_000
+          })
+        );
+      }
+    };
+
+    try {
+      const tabSync = createTrackedTabSync({store});
+      const fn = jest.fn().mockResolvedValue('ok');
+      const result = await tabSync.tryWithRefreshLock(fn);
+
+      expect(result).toEqual({ran: false});
+      expect(fn).not.toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(navigator, 'locks', {
+        value: originalLocks,
+        configurable: true
+      });
+    }
+  });
+
   test('setupListeners applies tokens via localStorage storage event fallback', async () => {
     const tabSync = createTrackedTabSync({store});
     const onTokensUpdated = jest.fn();
@@ -230,6 +274,37 @@ describe('tabSync', () => {
 
     expect(store.getSessionItem(StorageKeys.accessToken)).toBeNull();
     expect(onSessionCleared).toHaveBeenCalled();
+  });
+
+  test('setupListeners clears mirrored refresh token on session_cleared when insecure storage is configured', async () => {
+    const removeSessionItem = jest.fn();
+    const tabSync = createTrackedTabSync({
+      store,
+      insecureStorage: {setSessionItem: jest.fn(), removeSessionItem},
+      useInsecureForRefreshToken: true
+    });
+
+    tabSync.setupListeners({});
+
+    const message = {
+      type: 'session_cleared' as const,
+      tabId: 'other-tab-id'
+    };
+
+    const storageHandler = (
+      window.addEventListener as jest.Mock
+    ).mock.calls.find(([event]) => event === 'storage')?.[1] as
+      | ((event: StorageEvent) => void)
+      | undefined;
+
+    storageHandler?.({
+      key: 'kinde_token_sync',
+      newValue: JSON.stringify(message)
+    } as StorageEvent);
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(removeSessionItem).toHaveBeenCalledWith(StorageKeys.refreshToken);
   });
 
   test('setupVisibilitySync invokes callback when the document becomes visible', () => {

--- a/src/state/tabSync.ts
+++ b/src/state/tabSync.ts
@@ -1,0 +1,369 @@
+import {
+  StorageKeys,
+  type RefreshTokenResult,
+  type RefreshTokenResultSuccess
+} from '../kindeUtils';
+import type {Store} from './store.types';
+
+const CHANNEL_NAME = 'kinde-auth-pkce';
+const LOCK_NAME = 'kinde-token-refresh';
+const LS_LOCK_KEY = 'kinde_refresh_lock';
+const LS_SYNC_KEY = 'kinde_token_sync';
+const LOCK_TTL_MS = 30_000;
+const BROADCAST_WAIT_MS = 10_000;
+
+export type TabSyncTokens = {
+  accessToken: string;
+  idToken: string;
+  refreshToken?: string;
+};
+
+type TabSyncMessage =
+  | {type: 'tokens_updated'; tokens: TabSyncTokens; tabId: string}
+  | {type: 'session_cleared'; tabId: string};
+
+type SessionManagerLike = {
+  setSessionItem<T>(key: StorageKeys, value: T): void;
+};
+
+export type TabSyncOptions = {
+  store: Store;
+  /** When set, refresh tokens are mirrored to insecure storage (localhost). */
+  insecureStorage?: SessionManagerLike | null;
+  useInsecureForRefreshToken?: boolean;
+};
+
+export type TabSync = {
+  tabId: string;
+  applyTokens: (tokens: TabSyncTokens) => Promise<void>;
+  applyTokensFromResult: (result: RefreshTokenResult) => Promise<void>;
+  broadcastTokens: (tokens: TabSyncTokens) => void;
+  broadcastSessionCleared: () => void;
+  tryWithRefreshLock: <T>(
+    fn: () => Promise<T>
+  ) => Promise<{ran: true; value: T} | {ran: false}>;
+  waitForTokenBroadcast: (timeoutMs?: number) => Promise<TabSyncTokens | null>;
+  setupListeners: (handlers: {
+    onTokensUpdated?: (tokens: TabSyncTokens) => void;
+    onSessionCleared?: () => void;
+  }) => () => void;
+  setupVisibilitySync: (onVisible: () => void | Promise<void>) => () => void;
+  dispose: () => void;
+};
+
+const isBrowser = (): boolean =>
+  typeof window !== 'undefined' &&
+  typeof document !== 'undefined' &&
+  typeof window.addEventListener === 'function';
+
+const getTabId = (): string => {
+  if (!isBrowser()) return 'server';
+  const key = 'kinde_tab_id';
+  let id = sessionStorage.getItem(key);
+  if (!id) {
+    id =
+      typeof crypto !== 'undefined' && 'randomUUID' in crypto
+        ? crypto.randomUUID()
+        : `tab_${Date.now()}_${Math.random().toString(36).slice(2)}`;
+    sessionStorage.setItem(key, id);
+  }
+  return id;
+};
+
+const isSuccessResult = (
+  result: RefreshTokenResult
+): result is RefreshTokenResultSuccess =>
+  result.success === true &&
+  typeof result[StorageKeys.accessToken] === 'string';
+
+export const createTabSync = (options: TabSyncOptions): TabSync => {
+  const {store, insecureStorage, useInsecureForRefreshToken = false} = options;
+  const tabId = getTabId();
+
+  let channel: BroadcastChannel | null = null;
+  let lsListener: ((event: StorageEvent) => void) | null = null;
+  const pendingBroadcastWaits = new Set<{
+    resolve: (tokens: TabSyncTokens | null) => void;
+    reject: (error: Error) => void;
+  }>();
+
+  const getChannel = (): BroadcastChannel | null => {
+    if (!isBrowser() || typeof BroadcastChannel === 'undefined') {
+      return null;
+    }
+    if (!channel) {
+      channel = new BroadcastChannel(CHANNEL_NAME);
+    }
+    return channel;
+  };
+
+  const notifyBroadcastWaiters = (tokens: TabSyncTokens | null) => {
+    pendingBroadcastWaits.forEach(({resolve}) => resolve(tokens));
+    pendingBroadcastWaits.clear();
+  };
+
+  const postMessage = (message: TabSyncMessage): void => {
+    const ch = getChannel();
+    if (ch) {
+      ch.postMessage(message);
+      return;
+    }
+    if (!isBrowser()) return;
+    try {
+      localStorage.setItem(
+        LS_SYNC_KEY,
+        JSON.stringify({...message, at: Date.now()})
+      );
+      localStorage.removeItem(LS_SYNC_KEY);
+    } catch {
+      // localStorage may be unavailable
+    }
+  };
+
+  const applyTokens = async (tokens: TabSyncTokens): Promise<void> => {
+    const items: Partial<Record<StorageKeys, string>> = {
+      [StorageKeys.accessToken]: tokens.accessToken,
+      [StorageKeys.idToken]: tokens.idToken
+    };
+    if (tokens.refreshToken) {
+      items[StorageKeys.refreshToken] = tokens.refreshToken;
+    }
+    await store.setItems(items);
+
+    if (useInsecureForRefreshToken && insecureStorage && tokens.refreshToken) {
+      insecureStorage.setSessionItem(
+        StorageKeys.refreshToken,
+        tokens.refreshToken
+      );
+    }
+  };
+
+  const applyTokensFromResult = async (
+    result: RefreshTokenResult
+  ): Promise<void> => {
+    if (!isSuccessResult(result)) return;
+
+    const accessToken = result[StorageKeys.accessToken]!;
+    const idToken = result[StorageKeys.idToken];
+    const refreshToken = result[StorageKeys.refreshToken];
+
+    await applyTokens({
+      accessToken,
+      idToken: idToken ?? '',
+      ...(refreshToken ? {refreshToken} : {})
+    });
+  };
+
+  const broadcastTokens = (tokens: TabSyncTokens): void => {
+    postMessage({type: 'tokens_updated', tokens, tabId});
+  };
+
+  const broadcastSessionCleared = (): void => {
+    postMessage({type: 'session_cleared', tabId});
+  };
+
+  const readLsLock = (): {tabId: string; until: number} | null => {
+    if (!isBrowser()) return null;
+    try {
+      const raw = localStorage.getItem(LS_LOCK_KEY);
+      if (!raw) return null;
+      return JSON.parse(raw) as {tabId: string; until: number};
+    } catch {
+      return null;
+    }
+  };
+
+  const writeLsLock = (): void => {
+    if (!isBrowser()) return;
+    localStorage.setItem(
+      LS_LOCK_KEY,
+      JSON.stringify({tabId, until: Date.now() + LOCK_TTL_MS})
+    );
+  };
+
+  const clearLsLockIfOwner = (): void => {
+    if (!isBrowser()) return;
+    const lock = readLsLock();
+    if (lock?.tabId === tabId) {
+      localStorage.removeItem(LS_LOCK_KEY);
+    }
+  };
+
+  const tryWithRefreshLock = async <T>(
+    fn: () => Promise<T>
+  ): Promise<{ran: true; value: T} | {ran: false}> => {
+    if (!isBrowser()) {
+      return {ran: true, value: await fn()};
+    }
+
+    if (navigator.locks?.request) {
+      let acquired = false;
+      let result!: T;
+
+      await navigator.locks.request(
+        LOCK_NAME,
+        {ifAvailable: true},
+        async (lock) => {
+          if (!lock) return;
+          acquired = true;
+          result = await fn();
+        }
+      );
+
+      if (acquired) {
+        return {ran: true, value: result};
+      }
+      return {ran: false};
+    }
+
+    const existing = readLsLock();
+    if (existing && existing.until > Date.now() && existing.tabId !== tabId) {
+      return {ran: false};
+    }
+
+    writeLsLock();
+    try {
+      return {ran: true, value: await fn()};
+    } finally {
+      clearLsLockIfOwner();
+    }
+  };
+
+  const waitForTokenBroadcast = (
+    timeoutMs = BROADCAST_WAIT_MS
+  ): Promise<TabSyncTokens | null> =>
+    new Promise((resolve, reject) => {
+      const entry = {resolve, reject};
+      pendingBroadcastWaits.add(entry);
+
+      const timer = window.setTimeout(() => {
+        pendingBroadcastWaits.delete(entry);
+        resolve(null);
+      }, timeoutMs);
+
+      const originalResolve = entry.resolve;
+      entry.resolve = (tokens) => {
+        window.clearTimeout(timer);
+        originalResolve(tokens);
+      };
+    });
+
+  const dispatchMessage = (
+    message: TabSyncMessage,
+    handlers: {
+      onTokensUpdated?: (tokens: TabSyncTokens) => void;
+      onSessionCleared?: () => void;
+    }
+  ): void => {
+    if (message.tabId === tabId) return;
+
+    if (message.type === 'tokens_updated') {
+      void applyTokens(message.tokens).then(() => {
+        handlers.onTokensUpdated?.(message.tokens);
+      });
+      notifyBroadcastWaiters(message.tokens);
+    } else if (message.type === 'session_cleared') {
+      store.reset();
+      handlers.onSessionCleared?.();
+      notifyBroadcastWaiters(null);
+    }
+  };
+
+  const setupListeners = (handlers: {
+    onTokensUpdated?: (tokens: TabSyncTokens) => void;
+    onSessionCleared?: () => void;
+  }): (() => void) => {
+    const ch = getChannel();
+    const onChannelMessage = (event: MessageEvent<TabSyncMessage>) => {
+      dispatchMessage(event.data, handlers);
+    };
+
+    if (ch) {
+      ch.addEventListener('message', onChannelMessage);
+    }
+
+    lsListener = (event: StorageEvent) => {
+      if (event.key !== LS_SYNC_KEY || !event.newValue) return;
+      try {
+        const message = JSON.parse(event.newValue) as TabSyncMessage;
+        dispatchMessage(message, handlers);
+      } catch {
+        // ignore malformed payloads
+      }
+    };
+
+    if (isBrowser()) {
+      window.addEventListener('storage', lsListener);
+    }
+
+    return () => {
+      ch?.removeEventListener('message', onChannelMessage);
+      if (lsListener) {
+        window.removeEventListener('storage', lsListener);
+        lsListener = null;
+      }
+    };
+  };
+
+  const setupVisibilitySync = (
+    onVisible: () => void | Promise<void>
+  ): (() => void) => {
+    if (!isBrowser()) return () => undefined;
+
+    const onVisibilityChange = () => {
+      if (document.visibilityState === 'visible') {
+        void onVisible();
+      }
+    };
+
+    const onFocus = () => {
+      void onVisible();
+    };
+
+    document.addEventListener('visibilitychange', onVisibilityChange);
+    window.addEventListener('focus', onFocus);
+
+    return () => {
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+      window.removeEventListener('focus', onFocus);
+    };
+  };
+
+  const dispose = (): void => {
+    channel?.close();
+    channel = null;
+    pendingBroadcastWaits.forEach(({reject}) =>
+      reject(new Error('Tab sync disposed'))
+    );
+    pendingBroadcastWaits.clear();
+  };
+
+  return {
+    tabId,
+    applyTokens,
+    applyTokensFromResult,
+    broadcastTokens,
+    broadcastSessionCleared,
+    tryWithRefreshLock,
+    waitForTokenBroadcast,
+    setupListeners,
+    setupVisibilitySync,
+    dispose
+  };
+};
+
+export const tokensFromRefreshResult = (
+  result: RefreshTokenResult
+): TabSyncTokens | null => {
+  if (!isSuccessResult(result)) return null;
+  const accessToken = result[StorageKeys.accessToken]!;
+  const idToken = result[StorageKeys.idToken];
+  if (!idToken) return null;
+  return {
+    accessToken,
+    idToken,
+    ...(result[StorageKeys.refreshToken]
+      ? {refreshToken: result[StorageKeys.refreshToken]}
+      : {})
+  };
+};

--- a/src/state/tabSync.ts
+++ b/src/state/tabSync.ts
@@ -85,6 +85,7 @@ export const createTabSync = (options: TabSyncOptions): TabSync => {
   const pendingBroadcastWaits = new Set<{
     resolve: (tokens: TabSyncTokens | null) => void;
     reject: (error: Error) => void;
+    clearTimer: () => void;
   }>();
 
   const getChannel = (): BroadcastChannel | null => {
@@ -98,7 +99,10 @@ export const createTabSync = (options: TabSyncOptions): TabSync => {
   };
 
   const notifyBroadcastWaiters = (tokens: TabSyncTokens | null) => {
-    pendingBroadcastWaits.forEach(({resolve}) => resolve(tokens));
+    pendingBroadcastWaits.forEach(({resolve, clearTimer}) => {
+      clearTimer();
+      resolve(tokens);
+    });
     pendingBroadcastWaits.clear();
   };
 
@@ -147,9 +151,11 @@ export const createTabSync = (options: TabSyncOptions): TabSync => {
     const idToken = result[StorageKeys.idToken];
     const refreshToken = result[StorageKeys.refreshToken];
 
+    if (!idToken) return;
+
     await applyTokens({
       accessToken,
-      idToken: idToken ?? '',
+      idToken,
       ...(refreshToken ? {refreshToken} : {})
     });
   };
@@ -233,18 +239,32 @@ export const createTabSync = (options: TabSyncOptions): TabSync => {
     timeoutMs = BROADCAST_WAIT_MS
   ): Promise<TabSyncTokens | null> =>
     new Promise((resolve, reject) => {
-      const entry = {resolve, reject};
+      let timer: ReturnType<typeof setTimeout> | undefined;
+
+      const clearTimer = () => {
+        if (timer !== undefined) {
+          clearTimeout(timer);
+          timer = undefined;
+        }
+      };
+
+      const entry = {
+        resolve,
+        reject,
+        clearTimer
+      };
       pendingBroadcastWaits.add(entry);
 
-      const timer = window.setTimeout(() => {
+      timer = setTimeout(() => {
         pendingBroadcastWaits.delete(entry);
+        clearTimer();
         resolve(null);
       }, timeoutMs);
 
-      const originalResolve = entry.resolve;
       entry.resolve = (tokens) => {
-        window.clearTimeout(timer);
-        originalResolve(tokens);
+        clearTimer();
+        pendingBroadcastWaits.delete(entry);
+        resolve(tokens);
       };
     });
 
@@ -260,8 +280,8 @@ export const createTabSync = (options: TabSyncOptions): TabSync => {
     if (message.type === 'tokens_updated') {
       void applyTokens(message.tokens).then(() => {
         handlers.onTokensUpdated?.(message.tokens);
+        notifyBroadcastWaiters(message.tokens);
       });
-      notifyBroadcastWaiters(message.tokens);
     } else if (message.type === 'session_cleared') {
       store.reset();
       handlers.onSessionCleared?.();
@@ -332,9 +352,10 @@ export const createTabSync = (options: TabSyncOptions): TabSync => {
   const dispose = (): void => {
     channel?.close();
     channel = null;
-    pendingBroadcastWaits.forEach(({reject}) =>
-      reject(new Error('Tab sync disposed'))
-    );
+    pendingBroadcastWaits.forEach(({reject, clearTimer}) => {
+      clearTimer();
+      reject(new Error('Tab sync disposed'));
+    });
     pendingBroadcastWaits.clear();
   };
 

--- a/src/state/tabSync.ts
+++ b/src/state/tabSync.ts
@@ -368,22 +368,30 @@ export const createTabSync = (options: TabSyncOptions): TabSync => {
   ): (() => void) => {
     if (!isBrowser()) return () => undefined;
 
-    const onVisibilityChange = () => {
-      if (document.visibilityState === 'visible') {
+    let pendingCheck: ReturnType<typeof setTimeout> | undefined;
+
+    const scheduleCheck = () => {
+      if (pendingCheck !== undefined) return;
+      pendingCheck = setTimeout(() => {
+        pendingCheck = undefined;
         void onVisible();
-      }
+      }, 0);
     };
 
-    const onFocus = () => {
-      void onVisible();
+    const onVisibilityChange = () => {
+      if (document.visibilityState === 'visible') scheduleCheck();
     };
 
     document.addEventListener('visibilitychange', onVisibilityChange);
-    window.addEventListener('focus', onFocus);
+    window.addEventListener('focus', scheduleCheck);
 
     return () => {
+      if (pendingCheck !== undefined) {
+        clearTimeout(pendingCheck);
+        pendingCheck = undefined;
+      }
       document.removeEventListener('visibilitychange', onVisibilityChange);
-      window.removeEventListener('focus', onFocus);
+      window.removeEventListener('focus', scheduleCheck);
     };
   };
 

--- a/src/state/tabSync.ts
+++ b/src/state/tabSync.ts
@@ -60,13 +60,24 @@ const isBrowser = (): boolean =>
 const getTabId = (): string => {
   if (!isBrowser()) return 'server';
   const key = 'kinde_tab_id';
-  let id = sessionStorage.getItem(key);
+
+  let id: string | null = null;
+  try {
+    id = sessionStorage.getItem(key);
+  } catch {
+    // sessionStorage may be unavailable (e.g. private mode)
+  }
+
   if (!id) {
     id =
       typeof crypto !== 'undefined' && 'randomUUID' in crypto
         ? crypto.randomUUID()
         : `tab_${Date.now()}_${Math.random().toString(36).slice(2)}`;
-    sessionStorage.setItem(key, id);
+    try {
+      sessionStorage.setItem(key, id);
+    } catch {
+      // ignore persistence failures
+    }
   }
   return id;
 };

--- a/src/state/tabSync.ts
+++ b/src/state/tabSync.ts
@@ -309,10 +309,16 @@ export const createTabSync = (options: TabSyncOptions): TabSync => {
     if (message.tabId === tabId) return;
 
     if (message.type === 'tokens_updated') {
-      void applyTokens(message.tokens).then(() => {
-        handlers.onTokensUpdated?.(message.tokens);
-        notifyBroadcastWaiters(message.tokens);
-      });
+      void applyTokens(message.tokens)
+        .then(() => {
+          handlers.onTokensUpdated?.(message.tokens);
+        })
+        .catch((error) => {
+          console.error('Failed to apply synced tokens:', error);
+        })
+        .finally(() => {
+          notifyBroadcastWaiters(message.tokens);
+        });
     } else if (message.type === 'session_cleared') {
       store.reset();
       clearMirroredRefreshToken();

--- a/src/state/tabSync.ts
+++ b/src/state/tabSync.ts
@@ -82,7 +82,7 @@ const getTabId = (): string => {
   return id;
 };
 
-const isSuccessResult = (
+export const isSuccessResult = (
   result: RefreshTokenResult
 ): result is RefreshTokenResultSuccess =>
   result.success === true &&

--- a/src/state/tabSync.ts
+++ b/src/state/tabSync.ts
@@ -42,7 +42,9 @@ export type TabSync = {
   broadcastSessionCleared: () => void;
   tryWithRefreshLock: <T>(
     fn: () => Promise<T>
-  ) => Promise<{ran: true; value: T} | {ran: false}>;
+  ) => Promise<
+    {ran: true; value: T; usedAmbiguousFallback: boolean} | {ran: false}
+  >;
   waitForTokenBroadcast: (timeoutMs?: number) => Promise<TabSyncTokens | null>;
   setupListeners: (handlers: {
     onTokensUpdated?: (tokens: TabSyncTokens) => void;
@@ -215,9 +217,11 @@ export const createTabSync = (options: TabSyncOptions): TabSync => {
 
   const tryWithRefreshLock = async <T>(
     fn: () => Promise<T>
-  ): Promise<{ran: true; value: T} | {ran: false}> => {
+  ): Promise<
+    {ran: true; value: T; usedAmbiguousFallback: boolean} | {ran: false}
+  > => {
     if (!isBrowser()) {
-      return {ran: true, value: await fn()};
+      return {ran: true, value: await fn(), usedAmbiguousFallback: false};
     }
 
     if (typeof navigator !== 'undefined' && navigator.locks?.request) {
@@ -235,7 +239,7 @@ export const createTabSync = (options: TabSyncOptions): TabSync => {
       );
 
       if (acquired) {
-        return {ran: true, value: result};
+        return {ran: true, value: result, usedAmbiguousFallback: false};
       }
       return {ran: false};
     }
@@ -252,7 +256,11 @@ export const createTabSync = (options: TabSyncOptions): TabSync => {
     }
 
     try {
-      return {ran: true, value: await fn()};
+      return {
+        ran: true,
+        value: await fn(),
+        usedAmbiguousFallback: true
+      };
     } finally {
       clearLsLockIfOwner();
     }

--- a/src/state/tabSync.ts
+++ b/src/state/tabSync.ts
@@ -24,6 +24,7 @@ type TabSyncMessage =
 
 type SessionManagerLike = {
   setSessionItem<T>(key: StorageKeys, value: T): void;
+  removeSessionItem?: (key: StorageKeys) => void;
 };
 
 export type TabSyncOptions = {
@@ -124,6 +125,12 @@ export const createTabSync = (options: TabSyncOptions): TabSync => {
     }
   };
 
+  const clearMirroredRefreshToken = (): void => {
+    if (useInsecureForRefreshToken && insecureStorage?.removeSessionItem) {
+      insecureStorage.removeSessionItem(StorageKeys.refreshToken);
+    }
+  };
+
   const applyTokens = async (tokens: TabSyncTokens): Promise<void> => {
     const items: Partial<Record<StorageKeys, string>> = {
       [StorageKeys.accessToken]: tokens.accessToken,
@@ -202,7 +209,7 @@ export const createTabSync = (options: TabSyncOptions): TabSync => {
       return {ran: true, value: await fn()};
     }
 
-    if (navigator.locks?.request) {
+    if (typeof navigator !== 'undefined' && navigator.locks?.request) {
       let acquired = false;
       let result!: T;
 
@@ -228,6 +235,11 @@ export const createTabSync = (options: TabSyncOptions): TabSync => {
     }
 
     writeLsLock();
+    const acquired = readLsLock();
+    if (!acquired || acquired.tabId !== tabId || acquired.until <= Date.now()) {
+      return {ran: false};
+    }
+
     try {
       return {ran: true, value: await fn()};
     } finally {
@@ -284,6 +296,7 @@ export const createTabSync = (options: TabSyncOptions): TabSync => {
       });
     } else if (message.type === 'session_cleared') {
       store.reset();
+      clearMirroredRefreshToken();
       handlers.onSessionCleared?.();
       notifyBroadcastWaiters(null);
     }


### PR DESCRIPTION
# Explain your changes

## Cross-tab refresh leader + broadcast (primary fix)
Add a small module, e.g. [src/state/tabSync.ts](src/state/tabSync.ts):

1. Leader election before any refresh (use [navigator.locks.request](https://developer.mozilla.org/en-US/docs/Web/API/LockManager) with a localStorage fallback for older browsers).
2. Only the leader calls checkAuth / allows js-utils timer refresh to proceed.
3. On successful refresh, broadcast { accessToken, idToken, refreshToken } via BroadcastChannel('kinde-auth') (or localStorage sentinel key + storage event as fallback).
4. Follower tabs apply payload via store.setItems(...) and reset their refresh timer.

Wire this in [createKindeClient.ts](src/createKindeClient.ts) during init():

- Subscribe to broadcast → update in-memory store
- Wrap or gate refresh entry points:
  - post-checkAuth refresh outcomes
  - optional storageSettings.onRefreshHandler wrapper that delegates to default behavior only when leader (if we need timer coordination—evaluate whether wrapping is cleaner than re-calling checkAuth on broadcast only)

## Re-sync when tab becomes visible
On document.visibilitychange / window.focus, call checkAuth({ domain, clientId }) through the leader lock so background tabs pick up cookie/session changes after another tab refreshed or logged out.

## Align in-memory refresh after js-utils refresh (localhost + consistency)

After any successful refresh, ensure StorageKeys.refreshToken in active store matches insecure/cookie path (js-utils on localhost writes refresh only to getInsecureStorage(), leaving memory stale). Add a small helper called from broadcast handler and post-checkAuth success path.

## Deprecate-path hardening (secondary)

Update deprecated [useRefreshToken](src/createKindeClient.ts) to read refresh via localStorageAdapter.getSessionItem(StorageKeys.refreshToken) instead of raw localStorage.getItem(storageMap.refresh_token) so dev/local multi-tab behavior stays consistent with migration in [migrateLegacyRefreshTokenKey](src/createKindeClient.ts).

# Checklist

- [X] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [X] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
