### PR TITLE
fix: ensure user is hydrated on token refresh

### DIFF
--- a/src/createKindeClient.test.ts
+++ b/src/createKindeClient.test.ts
@@ -498,6 +498,24 @@ describe('on_session_restore_callback semantics', () => {
     expect(client.getUser()).toBeFalsy();
   });
 
+  it('clears previously stored user when session is not authenticated on init', async () => {
+    setWindowLocation();
+    mockIsAuthenticated.mockResolvedValue(false);
+    store.setItem(storageMap.user, {
+      id: 'kp:stale-user',
+      email: 'stale@x.com',
+      given_name: 'Stale',
+      family_name: 'User'
+    });
+
+    const client = await createKindeClient({
+      domain: 'https://example.kinde.com',
+      redirect_uri: 'http://localhost:3000/'
+    });
+
+    expect(client.getUser()).toBeFalsy();
+  });
+
   it('does not fire session restore callback on redirect handling load', async () => {
     const state = b64url({kinde: {event: 'login'}});
     setWindowLocation(`?code=auth-code&state=${state}`);
@@ -598,6 +616,12 @@ describe('visibility sync hydration', () => {
         family_name: 'User'
       })
     );
+    store.setItem(storageMap.user, {
+      id: 'kp:stale-user',
+      email: 'stale@x.com',
+      given_name: 'Stale',
+      family_name: 'User'
+    });
 
     const client = await createKindeClient({
       domain: 'https://example.kinde.com',
@@ -605,6 +629,13 @@ describe('visibility sync hydration', () => {
     });
 
     expect(client.getUser()).toBeFalsy();
+
+    store.setItem(storageMap.user, {
+      id: 'kp:stale-user',
+      email: 'stale@x.com',
+      given_name: 'Stale',
+      family_name: 'User'
+    });
 
     const visibilityHandler = (
       document.addEventListener as jest.Mock

--- a/src/createKindeClient.test.ts
+++ b/src/createKindeClient.test.ts
@@ -651,6 +651,51 @@ describe('visibility sync hydration', () => {
     expect(mockCheckAuth).toHaveBeenCalled();
     expect(client.getUser()).toBeFalsy();
   });
+
+  it('hydrates user after successful visibility-triggered checkAuth', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const accessToken = makeJwt({exp: now + 3600, sub: 'kp:user-1'});
+    const idToken = makeJwt({
+      sub: 'kp:user-1',
+      email: 'u@x.com',
+      given_name: 'Test',
+      family_name: 'User'
+    });
+
+    const client = await createKindeClient({
+      domain: 'https://example.kinde.com',
+      redirect_uri: 'http://localhost:3000/'
+    });
+
+    expect(client.getUser()).toBeFalsy();
+
+    mockCheckAuth.mockResolvedValue({
+      success: true,
+      [StorageKeys.accessToken]: accessToken,
+      [StorageKeys.idToken]: idToken,
+      [StorageKeys.refreshToken]: 'refresh-token'
+    });
+    mockIsAuthenticated.mockResolvedValue(true);
+
+    const visibilityHandler = (
+      document.addEventListener as jest.Mock
+    ).mock.calls.find(([event]) => event === 'visibilitychange')?.[1] as
+      | (() => void)
+      | undefined;
+
+    mockCheckAuth.mockClear();
+    visibilityHandler?.();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(mockCheckAuth).toHaveBeenCalled();
+    expect(client.getUser()).toMatchObject({
+      id: 'kp:user-1',
+      email: 'u@x.com',
+      given_name: 'Test',
+      family_name: 'User'
+    });
+  });
 });
 
 describe('legacy localStorage refresh key migration', () => {

--- a/src/createKindeClient.test.ts
+++ b/src/createKindeClient.test.ts
@@ -22,6 +22,7 @@ jest.mock('./kindeUtils', () => {
     setInsecureStorage: jest.fn(),
     checkAuth: jest.fn().mockResolvedValue({success: false}),
     exchangeAuthCode: jest.fn().mockResolvedValue({success: true}),
+    isAuthenticated: jest.fn().mockResolvedValue(false),
     getUserProfile: jest.fn().mockResolvedValue(undefined),
     navigateToKinde: jest.fn().mockImplementation((opts: {url: string}) => {
       (global as typeof globalThis & {location: {href: string}}).location.href =
@@ -36,7 +37,9 @@ import {
   checkAuth,
   exchangeAuthCode,
   getUserProfile,
-  storageSettings
+  isAuthenticated,
+  storageSettings,
+  StorageKeys
 } from './kindeUtils';
 import {store} from './state/store';
 import {SESSION_PREFIX, storageMap} from './constants';
@@ -46,6 +49,7 @@ const mockSetActiveStorage = setActiveStorage as jest.Mock;
 const mockCheckAuth = checkAuth as jest.Mock;
 const mockExchangeAuthCode = exchangeAuthCode as jest.Mock;
 const mockGetUserProfile = getUserProfile as jest.Mock;
+const mockIsAuthenticated = isAuthenticated as jest.Mock;
 const mockIsJWTActive = isJWTActive as jest.MockedFunction<typeof isJWTActive>;
 
 type StorageMock = {
@@ -384,6 +388,8 @@ describe('on_session_restore_callback semantics', () => {
     mockCheckAuth.mockClear();
     mockExchangeAuthCode.mockClear();
     mockGetUserProfile.mockReset();
+    mockIsAuthenticated.mockReset();
+    mockIsAuthenticated.mockResolvedValue(false);
     store.reset();
     Object.defineProperty(global, 'sessionStorage', {
       value: createStorageMock(),
@@ -405,7 +411,14 @@ describe('on_session_restore_callback semantics', () => {
 
   it('fires session restore callback on non-redirect authenticated load', async () => {
     setWindowLocation();
-    mockGetUserProfile.mockResolvedValue({id: 'kp:user-1', email: 'u@x.com'});
+    mockIsAuthenticated.mockResolvedValue(true);
+    mockGetUserProfile.mockResolvedValue({
+      id: 'kp:user-1',
+      givenName: 'Test',
+      familyName: 'User',
+      email: 'u@x.com',
+      picture: undefined
+    });
     const onSessionRestore = jest.fn();
 
     await createKindeClient({
@@ -416,12 +429,52 @@ describe('on_session_restore_callback semantics', () => {
 
     expect(onSessionRestore).toHaveBeenCalledTimes(1);
     expect(onSessionRestore).toHaveBeenCalledWith(
-      expect.objectContaining({id: 'kp:user-1'}),
+      expect.objectContaining({id: 'kp:user-1', email: 'u@x.com'}),
       expect.objectContaining({
         kindeOriginUrl: 'http://localhost:3000/',
         kinde: {event: 'session_restore'}
       })
     );
+  });
+
+  it('populates getUser on session restore without callback when id token is present', async () => {
+    setWindowLocation();
+    mockIsAuthenticated.mockResolvedValue(true);
+    mockGetUserProfile.mockResolvedValue(undefined);
+    store.setSessionItem(
+      StorageKeys.idToken,
+      makeJwt({
+        sub: 'kp:user-1',
+        email: 'u@x.com',
+        given_name: 'Test',
+        family_name: 'User'
+      })
+    );
+
+    const client = await createKindeClient({
+      domain: 'https://example.kinde.com',
+      redirect_uri: 'http://localhost:3000/'
+    });
+
+    expect(mockGetUserProfile).toHaveBeenCalled();
+    expect(client.getUser()).toMatchObject({
+      id: 'kp:user-1',
+      email: 'u@x.com',
+      given_name: 'Test',
+      family_name: 'User'
+    });
+  });
+
+  it('does not fetch user profile when session is not authenticated', async () => {
+    setWindowLocation();
+    mockIsAuthenticated.mockResolvedValue(false);
+
+    await createKindeClient({
+      domain: 'https://example.kinde.com',
+      redirect_uri: 'http://localhost:3000/'
+    });
+
+    expect(mockGetUserProfile).not.toHaveBeenCalled();
   });
 
   it('does not fire session restore callback on redirect handling load', async () => {

--- a/src/createKindeClient.test.ts
+++ b/src/createKindeClient.test.ts
@@ -519,6 +519,109 @@ describe('on_session_restore_callback semantics', () => {
   });
 });
 
+describe('visibility sync hydration', () => {
+  const setupVisibilityBrowserMocks = () => {
+    setWindowLocation();
+    Object.defineProperty(global, 'window', {
+      value: {
+        ...(global.window as object),
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn()
+      },
+      writable: true,
+      configurable: true
+    });
+    Object.defineProperty(global, 'document', {
+      value: {
+        visibilityState: 'visible',
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn()
+      },
+      writable: true,
+      configurable: true
+    });
+    Object.defineProperty(global, 'navigator', {
+      value: {
+        locks: {
+          request: async (
+            _name: string,
+            _options: {ifAvailable: boolean},
+            callback: (lock: object) => Promise<void>
+          ) => {
+            await callback({});
+          }
+        }
+      },
+      writable: true,
+      configurable: true
+    });
+    Object.defineProperty(global, 'BroadcastChannel', {
+      value: undefined,
+      writable: true,
+      configurable: true
+    });
+  };
+
+  beforeEach(() => {
+    mockSetActiveStorage.mockReset();
+    mockCheckAuth.mockClear();
+    mockCheckAuth.mockResolvedValue({success: false});
+    mockIsAuthenticated.mockReset();
+    mockIsAuthenticated.mockResolvedValue(false);
+    store.reset();
+    setupVisibilityBrowserMocks();
+    Object.defineProperty(global, 'sessionStorage', {
+      value: createStorageMock(),
+      writable: true,
+      configurable: true
+    });
+    Object.defineProperty(global, 'localStorage', {
+      value: createStorageMock(),
+      writable: true,
+      configurable: true
+    });
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    storageSettings.onRefreshHandler = undefined;
+    jest.clearAllMocks();
+  });
+
+  it('does not hydrate user from stale id token after failed visibility checkAuth', async () => {
+    store.setSessionItem(
+      StorageKeys.idToken,
+      makeJwt({
+        sub: 'kp:stale-user',
+        email: 'stale@x.com',
+        given_name: 'Stale',
+        family_name: 'User'
+      })
+    );
+
+    const client = await createKindeClient({
+      domain: 'https://example.kinde.com',
+      redirect_uri: 'http://localhost:3000/'
+    });
+
+    expect(client.getUser()).toBeFalsy();
+
+    const visibilityHandler = (
+      document.addEventListener as jest.Mock
+    ).mock.calls.find(([event]) => event === 'visibilitychange')?.[1] as
+      | (() => void)
+      | undefined;
+
+    mockCheckAuth.mockClear();
+    visibilityHandler?.();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(mockCheckAuth).toHaveBeenCalled();
+    expect(client.getUser()).toBeFalsy();
+  });
+});
+
 describe('legacy localStorage refresh key migration', () => {
   beforeEach(() => {
     mockSetActiveStorage.mockReset();

--- a/src/createKindeClient.test.ts
+++ b/src/createKindeClient.test.ts
@@ -477,6 +477,27 @@ describe('on_session_restore_callback semantics', () => {
     expect(mockGetUserProfile).not.toHaveBeenCalled();
   });
 
+  it('does not hydrate user from stale id token when session is not authenticated', async () => {
+    setWindowLocation();
+    mockIsAuthenticated.mockResolvedValue(false);
+    store.setSessionItem(
+      StorageKeys.idToken,
+      makeJwt({
+        sub: 'kp:stale-user',
+        email: 'stale@x.com',
+        given_name: 'Stale',
+        family_name: 'User'
+      })
+    );
+
+    const client = await createKindeClient({
+      domain: 'https://example.kinde.com',
+      redirect_uri: 'http://localhost:3000/'
+    });
+
+    expect(client.getUser()).toBeFalsy();
+  });
+
   it('does not fire session restore callback on redirect handling load', async () => {
     const state = b64url({kinde: {event: 'login'}});
     setWindowLocation(`?code=auth-code&state=${state}`);

--- a/src/createKindeClient.ts
+++ b/src/createKindeClient.ts
@@ -287,19 +287,6 @@ const createKindeClient = async (
       }
     }, 'Authentication check in progress in another tab');
 
-  tabSync.setupListeners({});
-  tabSync.setupVisibilitySync(() => {
-    void runCheckAuthWithTabSync().catch((error) => {
-      console.warn('checkAuth failed:', error);
-      on_error_callback?.({
-        error: 'ERR_CHECK_AUTH',
-        errorDescription: String(error),
-        state: '',
-        appState: {}
-      });
-    });
-  });
-
   const config = {
     audience,
     client_id,
@@ -471,6 +458,36 @@ const createKindeClient = async (
     return key === storageMap.access_token
       ? bundle?.access_token
       : bundle?.id_token;
+  };
+
+  const hydrateUserFromIdToken = (): KindeUser | undefined => {
+    const sessionToken = store.getSessionItem(StorageKeys.idToken) as
+      | string
+      | null
+      | undefined;
+    const idTokenRaw =
+      (typeof sessionToken === 'string' ? sessionToken : undefined) ||
+      readLegacyRawToken(storageMap.id_token);
+
+    if (!idTokenRaw) return;
+
+    try {
+      const claims = jwtDecode<JWT & KindeUser>(idTokenRaw);
+      if (!claims.sub) return;
+
+      const mappedUser: KindeUser = {
+        id: claims.sub,
+        given_name: claims.given_name,
+        family_name: claims.family_name,
+        email: claims.email,
+        picture: claims.picture
+      };
+
+      store.setItem(storageMap.user, mappedUser);
+      return mappedUser;
+    } catch {
+      return;
+    }
   };
 
   const getAccessToken = async () => {
@@ -691,7 +708,7 @@ const createKindeClient = async (
           tabSync.broadcastTokens(syncedTokens);
         }
 
-        const user = await getUserProfile();
+        const user = (await getUserProfile()) ?? hydrateUserFromIdToken();
         if (user) {
           on_redirect_callback?.(user, storedAppState);
         }
@@ -879,6 +896,7 @@ const createKindeClient = async (
         // On custom domains, refresh uses the httpOnly _kbrte cookie (credentials: include);
         // the refresh_token field is intentionally omitted from the POST body.
         await runCheckAuthWithTabSync();
+        hydrateUserFromIdToken();
       } catch (err) {
         console.warn('checkAuth failed:', err);
         on_error_callback?.({
@@ -934,24 +952,27 @@ const createKindeClient = async (
         return;
       }
 
-      if (on_session_restore_callback) {
-        try {
-          const user = await getUserProfile();
-          if (user) {
+      try {
+        hydrateUserFromIdToken();
+
+        const authed = await isAuthenticated();
+        if (authed) {
+          const user = (await getUserProfile()) ?? getUser();
+          if (user && on_session_restore_callback) {
             on_session_restore_callback(user, {
               kindeOriginUrl: window.location.href,
               kinde: {event: 'session_restore'}
             });
           }
-        } catch (error) {
-          console.warn('Error getting user profile', error);
-          on_error_callback?.({
-            error: 'ERR_GET_USER_PROFILE',
-            errorDescription: String(error),
-            state: '',
-            appState: {}
-          });
         }
+      } catch (error) {
+        console.warn('Error restoring user session', error);
+        on_error_callback?.({
+          error: 'ERR_GET_USER_PROFILE',
+          errorDescription: String(error),
+          state: '',
+          appState: {}
+        });
       }
 
       return;
@@ -983,6 +1004,27 @@ const createKindeClient = async (
       currentRedirectUri === `${expectedRedirectUri}/`
     );
   };
+
+  tabSync.setupListeners({
+    onTokensUpdated: () => {
+      hydrateUserFromIdToken();
+    }
+  });
+  tabSync.setupVisibilitySync(() => {
+    void runCheckAuthWithTabSync()
+      .then(() => {
+        hydrateUserFromIdToken();
+      })
+      .catch((error) => {
+        console.warn('checkAuth failed:', error);
+        on_error_callback?.({
+          error: 'ERR_CHECK_AUTH',
+          errorDescription: String(error),
+          state: '',
+          appState: {}
+        });
+      });
+  });
 
   await init();
 

--- a/src/createKindeClient.ts
+++ b/src/createKindeClient.ts
@@ -891,7 +891,6 @@ const createKindeClient = async (
         // On custom domains, refresh uses the httpOnly _kbrte cookie (credentials: include);
         // the refresh_token field is intentionally omitted from the POST body.
         await runCheckAuthWithTabSync();
-        await hydrateUserFromIdToken();
       } catch (err) {
         console.warn('checkAuth failed:', err);
         on_error_callback?.({
@@ -948,10 +947,9 @@ const createKindeClient = async (
       }
 
       try {
-        await hydrateUserFromIdToken();
-
         const authed = await isAuthenticated();
         if (authed) {
+          await hydrateUserFromIdToken();
           const user = (await getUserProfile()) ?? getUser();
           if (user && on_session_restore_callback) {
             on_session_restore_callback(user, {

--- a/src/createKindeClient.ts
+++ b/src/createKindeClient.ts
@@ -229,6 +229,7 @@ const createKindeClient = async (
 
     if (lock.ran && isSuccessResult(lock.value)) {
       await tabSync.applyTokensFromResult(lock.value);
+      await hydrateUserFromIdToken();
       const tokens = tokensFromRefreshResult(lock.value);
       if (tokens) {
         tabSync.broadcastTokens(tokens);
@@ -460,15 +461,8 @@ const createKindeClient = async (
       : bundle?.id_token;
   };
 
-  const hydrateUserFromIdToken = (): KindeUser | undefined => {
-    const sessionToken = store.getSessionItem(StorageKeys.idToken) as
-      | string
-      | null
-      | undefined;
-    const idTokenRaw =
-      (typeof sessionToken === 'string' ? sessionToken : undefined) ||
-      readLegacyRawToken(storageMap.id_token);
-
+  const hydrateUserFromIdToken = async (): Promise<KindeUser | undefined> => {
+    const idTokenRaw = await getIdToken();
     if (!idTokenRaw) return;
 
     try {
@@ -708,7 +702,8 @@ const createKindeClient = async (
           tabSync.broadcastTokens(syncedTokens);
         }
 
-        const user = (await getUserProfile()) ?? hydrateUserFromIdToken();
+        const user =
+          (await getUserProfile()) ?? (await hydrateUserFromIdToken());
         if (user) {
           on_redirect_callback?.(user, storedAppState);
         }
@@ -896,7 +891,7 @@ const createKindeClient = async (
         // On custom domains, refresh uses the httpOnly _kbrte cookie (credentials: include);
         // the refresh_token field is intentionally omitted from the POST body.
         await runCheckAuthWithTabSync();
-        hydrateUserFromIdToken();
+        await hydrateUserFromIdToken();
       } catch (err) {
         console.warn('checkAuth failed:', err);
         on_error_callback?.({
@@ -953,7 +948,7 @@ const createKindeClient = async (
       }
 
       try {
-        hydrateUserFromIdToken();
+        await hydrateUserFromIdToken();
 
         const authed = await isAuthenticated();
         if (authed) {
@@ -1007,13 +1002,13 @@ const createKindeClient = async (
 
   tabSync.setupListeners({
     onTokensUpdated: () => {
-      hydrateUserFromIdToken();
+      void hydrateUserFromIdToken();
     }
   });
   tabSync.setupVisibilitySync(() => {
     void runCheckAuthWithTabSync()
-      .then(() => {
-        hydrateUserFromIdToken();
+      .then(async () => {
+        await hydrateUserFromIdToken();
       })
       .catch((error) => {
         console.warn('checkAuth failed:', error);

--- a/src/createKindeClient.ts
+++ b/src/createKindeClient.ts
@@ -1005,8 +1005,10 @@ const createKindeClient = async (
   });
   tabSync.setupVisibilitySync(() => {
     void runCheckAuthWithTabSync()
-      .then(async () => {
-        await hydrateUserFromIdToken();
+      .then(async (result) => {
+        if (isSuccessResult(result)) {
+          await hydrateUserFromIdToken();
+        }
       })
       .catch((error) => {
         console.warn('checkAuth failed:', error);

--- a/src/createKindeClient.ts
+++ b/src/createKindeClient.ts
@@ -957,6 +957,8 @@ const createKindeClient = async (
               kinde: {event: 'session_restore'}
             });
           }
+        } else {
+          store.removeItem(storageMap.user);
         }
       } catch (error) {
         console.warn('Error restoring user session', error);
@@ -1005,9 +1007,11 @@ const createKindeClient = async (
   });
   tabSync.setupVisibilitySync(() => {
     void runCheckAuthWithTabSync()
-      .then(async (result) => {
-        if (isSuccessResult(result)) {
+      .then(async () => {
+        if (await isAuthenticated()) {
           await hydrateUserFromIdToken();
+        } else {
+          store.removeItem(storageMap.user);
         }
       })
       .catch((error) => {


### PR DESCRIPTION
# Explain your changes

Changes to the Auth PCKE have resulted in the user sometimes experiencing a loss of their user locally when the token is refreshed. 

This change adds a method to ensure user is Hydrated from the id_token, 
_Suppose there is a related issue with enough detail for a reviewer to understand your changes fully. In that case, you can omit an explanation and instead include either “Fixes #XX” or “Updates #XX” where “XX” is the issue number._

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
