### PR TITLE
Allow getAccessToken to refresh

### DIFF
--- a/src/createKindeClient.test.ts
+++ b/src/createKindeClient.test.ts
@@ -23,6 +23,7 @@ jest.mock('./kindeUtils', () => {
     checkAuth: jest.fn().mockResolvedValue({success: false}),
     exchangeAuthCode: jest.fn().mockResolvedValue({success: true}),
     getUserProfile: jest.fn().mockResolvedValue(undefined),
+    refreshToken: jest.fn().mockResolvedValue({success: false}),
     navigateToKinde: jest.fn().mockImplementation((opts: {url: string}) => {
       (global as typeof globalThis & {location: {href: string}}).location.href =
         opts.url;
@@ -36,7 +37,9 @@ import {
   checkAuth,
   exchangeAuthCode,
   getUserProfile,
-  storageSettings
+  refreshToken,
+  storageSettings,
+  StorageKeys
 } from './kindeUtils';
 import {store} from './state/store';
 import {SESSION_PREFIX, storageMap} from './constants';
@@ -46,6 +49,7 @@ const mockSetActiveStorage = setActiveStorage as jest.Mock;
 const mockCheckAuth = checkAuth as jest.Mock;
 const mockExchangeAuthCode = exchangeAuthCode as jest.Mock;
 const mockGetUserProfile = getUserProfile as jest.Mock;
+const mockRefreshToken = refreshToken as jest.Mock;
 const mockIsJWTActive = isJWTActive as jest.MockedFunction<typeof isJWTActive>;
 
 type StorageMock = {
@@ -573,5 +577,107 @@ describe('storageSettings.useInsecureForRefreshToken configuration', () => {
     });
 
     expect(storageSettings.useInsecureForRefreshToken).toBe(true);
+  });
+});
+
+describe('getAccessToken refresh behaviour', () => {
+  const domain = 'https://example.kinde.com';
+
+  beforeEach(() => {
+    mockSetActiveStorage.mockReset();
+    mockCheckAuth.mockClear();
+    mockRefreshToken.mockReset();
+    mockIsJWTActive.mockReset();
+    store.reset();
+    Object.defineProperty(global, 'sessionStorage', {
+      value: createStorageMock(),
+      writable: true,
+      configurable: true
+    });
+    Object.defineProperty(global, 'localStorage', {
+      value: createStorageMock(),
+      writable: true,
+      configurable: true
+    });
+    Object.defineProperty(global, 'BroadcastChannel', {
+      value: undefined,
+      writable: true,
+      configurable: true
+    });
+    storageSettings.onRefreshHandler = undefined;
+  });
+
+  afterEach(() => {
+    storageSettings.onRefreshHandler = undefined;
+    jest.clearAllMocks();
+  });
+
+  it('returns an active token without calling refresh', async () => {
+    setWindowLocation();
+    mockIsJWTActive.mockReturnValue(true);
+    const activeJwt = makeJwt({exp: Math.floor(Date.now() / 1000) + 600});
+    store.setSessionItem(StorageKeys.accessToken, activeJwt);
+
+    const client = await createKindeClient({
+      domain,
+      redirect_uri: 'http://localhost:3000/'
+    });
+
+    const token = await client.getAccessToken();
+
+    expect(token).toBe(activeJwt);
+    expect(mockRefreshToken).not.toHaveBeenCalled();
+  });
+
+  it('refreshes and returns a new token when the stored access token is expired', async () => {
+    setWindowLocation();
+    mockIsJWTActive.mockReturnValue(false);
+    const expiredJwt = makeJwt({exp: Math.floor(Date.now() / 1000) - 60});
+    const freshJwt = makeJwt({exp: Math.floor(Date.now() / 1000) + 300});
+    store.setSessionItem(StorageKeys.accessToken, expiredJwt);
+    store.setSessionItem(
+      StorageKeys.idToken,
+      makeJwt({exp: Math.floor(Date.now() / 1000) + 3600})
+    );
+    mockRefreshToken.mockResolvedValue({
+      success: true,
+      [StorageKeys.accessToken]: freshJwt,
+      [StorageKeys.idToken]: makeJwt({
+        exp: Math.floor(Date.now() / 1000) + 3600
+      })
+    });
+
+    const client = await createKindeClient({
+      domain,
+      redirect_uri: 'http://localhost:3000/'
+    });
+
+    const token = await client.getAccessToken();
+
+    expect(mockRefreshToken).toHaveBeenCalled();
+    expect(token).toBe(freshJwt);
+  });
+
+  it('returns undefined without clearing storage when refresh fails', async () => {
+    setWindowLocation();
+    mockIsJWTActive.mockReturnValue(false);
+    const expiredJwt = makeJwt({exp: Math.floor(Date.now() / 1000) - 60});
+    store.setSessionItem(StorageKeys.accessToken, expiredJwt);
+    store.setSessionItem(StorageKeys.refreshToken, 'rt-keep');
+    mockRefreshToken.mockResolvedValue({
+      success: false,
+      error: 'invalid_grant'
+    });
+
+    const client = await createKindeClient({
+      domain,
+      redirect_uri: 'http://localhost:3000/'
+    });
+
+    const token = await client.getAccessToken();
+
+    expect(token).toBeUndefined();
+    expect(store.getSessionItem(StorageKeys.refreshToken)).toBe('rt-keep');
+    expect(store.getSessionItem(StorageKeys.accessToken)).toBe(expiredJwt);
   });
 });

--- a/src/createKindeClient.test.ts
+++ b/src/createKindeClient.test.ts
@@ -911,6 +911,40 @@ describe('getAccessToken refresh behaviour', () => {
     expect(token).toBe(freshJwt);
   });
 
+  it('deduplicates concurrent getAccessToken refresh attempts in the same tab', async () => {
+    setWindowLocation();
+    mockIsJWTActive.mockReturnValue(false);
+    const expiredJwt = makeJwt({exp: Math.floor(Date.now() / 1000) - 60});
+    const freshJwt = makeJwt({exp: Math.floor(Date.now() / 1000) + 300});
+    store.setSessionItem(StorageKeys.accessToken, expiredJwt);
+    store.setSessionItem(
+      StorageKeys.idToken,
+      makeJwt({exp: Math.floor(Date.now() / 1000) + 3600})
+    );
+    mockRefreshToken.mockClear();
+    mockRefreshToken.mockResolvedValue({
+      success: true,
+      [StorageKeys.accessToken]: freshJwt,
+      [StorageKeys.idToken]: makeJwt({
+        exp: Math.floor(Date.now() / 1000) + 3600
+      })
+    });
+
+    const client = await createKindeClient({
+      domain,
+      redirect_uri: 'http://localhost:3000/'
+    });
+
+    const [first, second] = await Promise.all([
+      client.getAccessToken(),
+      client.getAccessToken()
+    ]);
+
+    expect(mockRefreshToken).toHaveBeenCalledTimes(1);
+    expect(first).toBe(freshJwt);
+    expect(second).toBe(freshJwt);
+  });
+
   it('returns undefined without clearing storage when refresh fails', async () => {
     setWindowLocation();
     mockIsJWTActive.mockReturnValue(false);

--- a/src/createKindeClient.test.ts
+++ b/src/createKindeClient.test.ts
@@ -838,6 +838,7 @@ describe('getAccessToken refresh behaviour', () => {
   beforeEach(() => {
     mockSetActiveStorage.mockReset();
     mockCheckAuth.mockClear();
+    mockCheckAuth.mockResolvedValue({success: false});
     mockRefreshToken.mockReset();
     mockIsJWTActive.mockReset();
     store.reset();

--- a/src/createKindeClient.test.ts
+++ b/src/createKindeClient.test.ts
@@ -41,7 +41,8 @@ import {
   refreshToken,
   isAuthenticated,
   storageSettings,
-  StorageKeys
+  StorageKeys,
+  RefreshType
 } from './kindeUtils';
 import {store} from './state/store';
 import {SESSION_PREFIX, storageMap} from './constants';
@@ -907,7 +908,40 @@ describe('getAccessToken refresh behaviour', () => {
 
     const token = await client.getAccessToken();
 
-    expect(mockRefreshToken).toHaveBeenCalled();
+    expect(mockRefreshToken).toHaveBeenCalledWith(
+      expect.objectContaining({refreshType: RefreshType.refreshToken})
+    );
+    expect(token).toBe(freshJwt);
+  });
+
+  it('uses cookie refresh on a production custom domain', async () => {
+    setWindowLocation('', 'app.example.com');
+    mockIsJWTActive.mockReturnValue(false);
+    const expiredJwt = makeJwt({exp: Math.floor(Date.now() / 1000) - 60});
+    const freshJwt = makeJwt({exp: Math.floor(Date.now() / 1000) + 300});
+    store.setSessionItem(StorageKeys.accessToken, expiredJwt);
+    store.setSessionItem(
+      StorageKeys.idToken,
+      makeJwt({exp: Math.floor(Date.now() / 1000) + 3600})
+    );
+    mockRefreshToken.mockResolvedValue({
+      success: true,
+      [StorageKeys.accessToken]: freshJwt,
+      [StorageKeys.idToken]: makeJwt({
+        exp: Math.floor(Date.now() / 1000) + 3600
+      })
+    });
+
+    const client = await createKindeClient({
+      domain: 'https://auth.example.com',
+      redirect_uri: 'http://app.example.com/'
+    });
+
+    const token = await client.getAccessToken();
+
+    expect(mockRefreshToken).toHaveBeenCalledWith(
+      expect.objectContaining({refreshType: RefreshType.cookie})
+    );
     expect(token).toBe(freshJwt);
   });
 

--- a/src/createKindeClient.ts
+++ b/src/createKindeClient.ts
@@ -221,7 +221,9 @@ const createKindeClient = async (
     }
   };
 
-  const withTabSyncCoordination = async (
+  let inFlightTabCoordination: Promise<RefreshTokenResult> | null = null;
+
+  const runTabSyncCoordination = async (
     operation: () => Promise<RefreshTokenResult>,
     inProgressErrorMessage: string
   ): Promise<RefreshTokenResult> => {
@@ -264,6 +266,27 @@ const createKindeClient = async (
       success: false,
       error: inProgressErrorMessage
     };
+  };
+
+  const withTabSyncCoordination = (
+    operation: () => Promise<RefreshTokenResult>,
+    inProgressErrorMessage: string
+  ): Promise<RefreshTokenResult> => {
+    if (inFlightTabCoordination) {
+      return inFlightTabCoordination;
+    }
+
+    const coordination = runTabSyncCoordination(
+      operation,
+      inProgressErrorMessage
+    ).finally(() => {
+      if (inFlightTabCoordination === coordination) {
+        inFlightTabCoordination = null;
+      }
+    });
+
+    inFlightTabCoordination = coordination;
+    return coordination;
   };
 
   const runRefreshWithTabSync = (

--- a/src/createKindeClient.ts
+++ b/src/createKindeClient.ts
@@ -517,7 +517,13 @@ const createKindeClient = async (
       return typeof tokenToReturn === 'string' ? tokenToReturn : undefined;
     }
 
-    const result = await runRefreshWithTabSync(RefreshType.refreshToken);
+    let result: RefreshTokenResult;
+    try {
+      result = await runRefreshWithTabSync(RefreshType.refreshToken);
+    } catch {
+      // Refresh failed — return undefined without clearing session storage.
+      return undefined;
+    }
 
     if (isSuccessResult(result)) {
       return result[StorageKeys.accessToken];

--- a/src/createKindeClient.ts
+++ b/src/createKindeClient.ts
@@ -542,7 +542,9 @@ const createKindeClient = async (
 
     let result: RefreshTokenResult;
     try {
-      result = await runRefreshWithTabSync(RefreshType.refreshToken);
+      result = await runRefreshWithTabSync(
+        isUseCookie ? RefreshType.cookie : RefreshType.refreshToken
+      );
     } catch {
       // Refresh failed — return undefined without clearing session storage.
       return undefined;

--- a/src/createKindeClient.ts
+++ b/src/createKindeClient.ts
@@ -460,6 +460,32 @@ const createKindeClient = async (
     return false;
   };
 
+  const isAuthLockContention = (error?: string): boolean =>
+    error === 'Authentication check in progress in another tab' ||
+    error === 'Token refresh in progress in another tab';
+
+  const getStoredAccessToken = async (): Promise<string | JWT | undefined> => {
+    const sessionToken = (await store.getSessionItem(
+      StorageKeys.accessToken
+    )) as string | undefined;
+    const legacyToken = readLegacyRawToken(storageMap.access_token);
+    return sessionToken || legacyToken;
+  };
+
+  const isStoredAccessTokenActive = (
+    token: string | JWT | undefined
+  ): boolean => {
+    if (!token) return false;
+    if (typeof token === 'string') {
+      try {
+        return isJWTActive(jwtDecode<JWT>(token));
+      } catch {
+        return false;
+      }
+    }
+    return isJWTActive(token);
+  };
+
   const readLegacyRawToken = (
     key: storageMap.access_token | storageMap.id_token
   ): string | undefined => {
@@ -474,10 +500,28 @@ const createKindeClient = async (
   };
 
   const getAccessToken = async () => {
-    // js-utils (exchangeAuthCode, checkAuth) stores under StorageKeys.accessToken
-    const sessionToken = await store.getSessionItem(StorageKeys.accessToken);
-    const legacyToken = readLegacyRawToken(storageMap.access_token);
-    return (sessionToken || legacyToken) as string | undefined;
+    const tokenToReturn = await getStoredAccessToken();
+
+    if (isStoredAccessTokenActive(tokenToReturn)) {
+      return typeof tokenToReturn === 'string' ? tokenToReturn : undefined;
+    }
+
+    const result = await runRefreshWithTabSync(RefreshType.refreshToken);
+
+    if (isSuccessResult(result)) {
+      return result[StorageKeys.accessToken];
+    }
+
+    if (isAuthLockContention(result.error)) {
+      const token = await getStoredAccessToken();
+      if (isStoredAccessTokenActive(token) && typeof token === 'string') {
+        return token;
+      }
+      return undefined;
+    }
+
+    // Refresh failed — return undefined without clearing session storage.
+    return undefined;
   };
 
   const getIdToken = async () => {

--- a/src/state/tabSync.test.ts
+++ b/src/state/tabSync.test.ts
@@ -158,6 +158,35 @@ describe('tabSync', () => {
     expect(store.getSessionItem(StorageKeys.idToken)).toBe('existing-id');
   });
 
+  test('tryWithRefreshLock deduplicates concurrent callers in the same tab', async () => {
+    const tabSync = createTrackedTabSync({store});
+    let resolveFn!: (value: string) => void;
+    const fn = jest.fn(
+      () =>
+        new Promise<string>((resolve) => {
+          resolveFn = resolve;
+        })
+    );
+
+    const first = tabSync.tryWithRefreshLock(fn);
+    const second = tabSync.tryWithRefreshLock(fn);
+
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    resolveFn('ok');
+
+    await expect(first).resolves.toEqual({
+      ran: true,
+      value: 'ok',
+      usedAmbiguousFallback: true
+    });
+    await expect(second).resolves.toEqual({
+      ran: true,
+      value: 'ok',
+      usedAmbiguousFallback: true
+    });
+  });
+
   test('tryWithRefreshLock runs the callback when the lock is available', async () => {
     const tabSync = createTrackedTabSync({store});
     const fn = jest.fn().mockResolvedValue('ok');

--- a/src/state/tabSync.test.ts
+++ b/src/state/tabSync.test.ts
@@ -140,19 +140,22 @@ describe('tabSync', () => {
     });
   });
 
-  test('applyTokensFromResult and tokensFromRefreshResult skip when idToken is missing', async () => {
+  test('applyTokensFromResult stores access token when idToken is missing', async () => {
     const tabSync = createTrackedTabSync({store});
+    store.setSessionItem(StorageKeys.idToken, 'existing-id');
     const result = {
       success: true as const,
       [StorageKeys.accessToken]: 'at-only'
     };
 
-    expect(tokensFromRefreshResult(result)).toBeNull();
+    expect(tokensFromRefreshResult(result)).toEqual({
+      accessToken: 'at-only'
+    });
 
     await tabSync.applyTokensFromResult(result);
 
-    expect(store.getSessionItem(StorageKeys.accessToken)).toBeNull();
-    expect(store.getSessionItem(StorageKeys.idToken)).toBeNull();
+    expect(store.getSessionItem(StorageKeys.accessToken)).toBe('at-only');
+    expect(store.getSessionItem(StorageKeys.idToken)).toBe('existing-id');
   });
 
   test('tryWithRefreshLock runs the callback when the lock is available', async () => {
@@ -299,6 +302,34 @@ describe('tabSync', () => {
 
     expect(store.getSessionItem(StorageKeys.accessToken)).toBe('access-jwt');
     expect(onTokensUpdated).toHaveBeenCalledWith(SAMPLE_TOKENS);
+  });
+
+  test('setupListeners applies access-only tokens_updated messages', async () => {
+    const tabSync = createTrackedTabSync({store});
+    const onTokensUpdated = jest.fn();
+    tabSync.setupListeners({onTokensUpdated});
+
+    const storageHandler = (
+      window.addEventListener as jest.Mock
+    ).mock.calls.find(([event]) => event === 'storage')?.[1] as
+      | ((event: StorageEvent) => void)
+      | undefined;
+
+    storageHandler?.({
+      key: 'kinde_token_sync',
+      newValue: JSON.stringify({
+        type: 'tokens_updated',
+        tabId: 'other-tab',
+        tokens: {accessToken: 'fresh-access'}
+      })
+    } as StorageEvent);
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(store.getSessionItem(StorageKeys.accessToken)).toBe('fresh-access');
+    expect(onTokensUpdated).toHaveBeenCalledWith({
+      accessToken: 'fresh-access'
+    });
   });
 
   test('setupListeners clears the store on session_cleared via storage event', async () => {

--- a/src/state/tabSync.ts
+++ b/src/state/tabSync.ts
@@ -14,7 +14,7 @@ const BROADCAST_WAIT_MS = 10_000;
 
 export type TabSyncTokens = {
   accessToken: string;
-  idToken: string;
+  idToken?: string;
   refreshToken?: string;
 };
 
@@ -146,9 +146,11 @@ export const createTabSync = (options: TabSyncOptions): TabSync => {
 
   const applyTokens = async (tokens: TabSyncTokens): Promise<void> => {
     const items: Partial<Record<StorageKeys, string>> = {
-      [StorageKeys.accessToken]: tokens.accessToken,
-      [StorageKeys.idToken]: tokens.idToken
+      [StorageKeys.accessToken]: tokens.accessToken
     };
+    if (tokens.idToken) {
+      items[StorageKeys.idToken] = tokens.idToken;
+    }
     if (tokens.refreshToken) {
       items[StorageKeys.refreshToken] = tokens.refreshToken;
     }
@@ -168,14 +170,14 @@ export const createTabSync = (options: TabSyncOptions): TabSync => {
     if (!isSuccessResult(result)) return;
 
     const accessToken = result[StorageKeys.accessToken]!;
-    const idToken = result[StorageKeys.idToken];
+    const idToken =
+      result[StorageKeys.idToken] ??
+      ((await store.getSessionItem(StorageKeys.idToken)) as string | null);
     const refreshToken = result[StorageKeys.refreshToken];
-
-    if (!idToken) return;
 
     await applyTokens({
       accessToken,
-      idToken,
+      ...(typeof idToken === 'string' ? {idToken} : {}),
       ...(refreshToken ? {refreshToken} : {})
     });
   };
@@ -425,10 +427,9 @@ export const tokensFromRefreshResult = (
   if (!isSuccessResult(result)) return null;
   const accessToken = result[StorageKeys.accessToken]!;
   const idToken = result[StorageKeys.idToken];
-  if (!idToken) return null;
   return {
     accessToken,
-    idToken,
+    ...(idToken ? {idToken} : {}),
     ...(result[StorageKeys.refreshToken]
       ? {refreshToken: result[StorageKeys.refreshToken]}
       : {})

--- a/src/state/tabSync.ts
+++ b/src/state/tabSync.ts
@@ -217,11 +217,15 @@ export const createTabSync = (options: TabSyncOptions): TabSync => {
     }
   };
 
-  const tryWithRefreshLock = async <T>(
+  type RefreshLockResult<T> =
+    | {ran: true; value: T; usedAmbiguousFallback: boolean}
+    | {ran: false};
+
+  let sameTabLockAttempt: Promise<RefreshLockResult<unknown>> | null = null;
+
+  const runCrossTabRefreshLock = async <T>(
     fn: () => Promise<T>
-  ): Promise<
-    {ran: true; value: T; usedAmbiguousFallback: boolean} | {ran: false}
-  > => {
+  ): Promise<RefreshLockResult<T>> => {
     if (!isBrowser()) {
       return {ran: true, value: await fn(), usedAmbiguousFallback: false};
     }
@@ -266,6 +270,22 @@ export const createTabSync = (options: TabSyncOptions): TabSync => {
     } finally {
       clearLsLockIfOwner();
     }
+  };
+
+  const tryWithRefreshLock = <T>(
+    fn: () => Promise<T>
+  ): Promise<RefreshLockResult<T>> => {
+    if (sameTabLockAttempt) {
+      return sameTabLockAttempt as Promise<RefreshLockResult<T>>;
+    }
+
+    const attempt = runCrossTabRefreshLock(fn).finally(() => {
+      if (sameTabLockAttempt === attempt) {
+        sameTabLockAttempt = null;
+      }
+    });
+    sameTabLockAttempt = attempt;
+    return attempt;
   };
 
   const waitForTokenBroadcast = (


### PR DESCRIPTION
Past updates to getAccessToken didn't include token refreshign, but it did previously. 

Extensive local testing has shown this adds additional stability to user sessions. 


- add token refreshing to getAccessToken
- allow cross-tab broadcast to work without idToken being present

# Explain your changes

_Suppose there is a related issue with enough detail for a reviewer to understand your changes fully. In that case, you can omit an explanation and instead include either “Fixes #XX” or “Updates #XX” where “XX” is the issue number._

# Checklist

- [X] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [X] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
