### PR TITLE
fix: ensure we verify that on logout, that we cancel any active refreshing

### DIFF
--- a/src/createKindeClient.test.ts
+++ b/src/createKindeClient.test.ts
@@ -42,7 +42,8 @@ import {
   isAuthenticated,
   storageSettings,
   StorageKeys,
-  RefreshType
+  RefreshType,
+  navigateToKinde
 } from './kindeUtils';
 import {store} from './state/store';
 import {SESSION_PREFIX, storageMap} from './constants';
@@ -54,6 +55,7 @@ const mockExchangeAuthCode = exchangeAuthCode as jest.Mock;
 const mockGetUserProfile = getUserProfile as jest.Mock;
 const mockRefreshToken = refreshToken as jest.Mock;
 const mockIsAuthenticated = isAuthenticated as jest.Mock;
+const mockNavigateToKinde = navigateToKinde as jest.Mock;
 const mockIsJWTActive = isJWTActive as jest.MockedFunction<typeof isJWTActive>;
 
 type StorageMock = {
@@ -1000,5 +1002,173 @@ describe('getAccessToken refresh behaviour', () => {
     expect(token).toBeUndefined();
     expect(store.getSessionItem(StorageKeys.refreshToken)).toBe('rt-keep');
     expect(store.getSessionItem(StorageKeys.accessToken)).toBe(expiredJwt);
+  });
+});
+
+describe('logout awaits in-flight refresh', () => {
+  beforeEach(() => {
+    mockSetActiveStorage.mockReset();
+    mockCheckAuth.mockClear();
+    mockCheckAuth.mockResolvedValue({success: false});
+    mockRefreshToken.mockReset();
+    mockNavigateToKinde.mockClear();
+    mockNavigateToKinde.mockImplementation((opts: {url: string}) => {
+      (global as typeof globalThis & {location: {href: string}}).location.href =
+        opts.url;
+    });
+    mockIsJWTActive.mockReset();
+    store.reset();
+    Object.defineProperty(global, 'sessionStorage', {
+      value: createStorageMock(),
+      writable: true,
+      configurable: true
+    });
+    Object.defineProperty(global, 'localStorage', {
+      value: createStorageMock(),
+      writable: true,
+      configurable: true
+    });
+    Object.defineProperty(global, 'BroadcastChannel', {
+      value: undefined,
+      writable: true,
+      configurable: true
+    });
+    storageSettings.onRefreshHandler = undefined;
+  });
+
+  afterEach(() => {
+    storageSettings.onRefreshHandler = undefined;
+    jest.clearAllMocks();
+  });
+
+  it('awaits an in-flight cookie refresh before navigating to /logout', async () => {
+    setWindowLocation('', 'app.example.com');
+    mockIsJWTActive.mockReturnValue(false);
+    const expiredJwt = makeJwt({exp: Math.floor(Date.now() / 1000) - 60});
+    const freshJwt = makeJwt({exp: Math.floor(Date.now() / 1000) + 300});
+    const idJwt = makeJwt({exp: Math.floor(Date.now() / 1000) + 3600});
+    store.setSessionItem(StorageKeys.accessToken, expiredJwt);
+    store.setSessionItem(StorageKeys.idToken, idJwt);
+
+    let resolveRefresh!: (value: {
+      success: true;
+      [StorageKeys.accessToken]: string;
+      [StorageKeys.idToken]: string;
+    }) => void;
+    mockRefreshToken.mockReturnValue(
+      new Promise((resolve) => {
+        resolveRefresh = resolve;
+      })
+    );
+
+    const client = await createKindeClient({
+      domain: 'https://auth.example.com',
+      redirect_uri: 'http://app.example.com/'
+    });
+
+    const accessPromise = client.getAccessToken();
+    // Allow the refresh coordination to start and take the in-flight slot.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const logoutPromise = client.logout();
+    await Promise.resolve();
+
+    expect(mockNavigateToKinde).not.toHaveBeenCalled();
+
+    resolveRefresh({
+      success: true,
+      [StorageKeys.accessToken]: freshJwt,
+      [StorageKeys.idToken]: idJwt
+    });
+
+    await accessPromise;
+    await logoutPromise;
+
+    expect(mockNavigateToKinde).toHaveBeenCalledTimes(1);
+    expect(mockNavigateToKinde).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: expect.stringContaining('https://auth.example.com/logout?')
+      })
+    );
+    expect(store.getSessionItem(StorageKeys.accessToken)).toBeNull();
+    expect(store.getSessionItem(StorageKeys.idToken)).toBeNull();
+    expect(store.getSessionItem(StorageKeys.refreshToken)).toBeNull();
+  });
+
+  it('does not apply in-flight refresh tokens after logout has started', async () => {
+    setWindowLocation('', 'app.example.com');
+    mockIsJWTActive.mockReturnValue(false);
+    const expiredJwt = makeJwt({exp: Math.floor(Date.now() / 1000) - 60});
+    const freshJwt = makeJwt({exp: Math.floor(Date.now() / 1000) + 300});
+    const idJwt = makeJwt({
+      exp: Math.floor(Date.now() / 1000) + 3600,
+      sub: 'user-1',
+      given_name: 'Ada',
+      family_name: 'Lovelace',
+      email: 'ada@example.com'
+    });
+    store.setSessionItem(StorageKeys.accessToken, expiredJwt);
+    store.setSessionItem(StorageKeys.idToken, idJwt);
+
+    let resolveRefresh!: (value: {
+      success: true;
+      [StorageKeys.accessToken]: string;
+      [StorageKeys.idToken]: string;
+    }) => void;
+    mockRefreshToken.mockReturnValue(
+      new Promise((resolve) => {
+        resolveRefresh = resolve;
+      })
+    );
+
+    const client = await createKindeClient({
+      domain: 'https://auth.example.com',
+      redirect_uri: 'http://app.example.com/'
+    });
+
+    const accessPromise = client.getAccessToken();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const logoutPromise = client.logout();
+    await Promise.resolve();
+
+    resolveRefresh({
+      success: true,
+      [StorageKeys.accessToken]: freshJwt,
+      [StorageKeys.idToken]: idJwt
+    });
+
+    const token = await accessPromise;
+    await logoutPromise;
+
+    // Refresh result discarded after logout started; local state stays cleared.
+    expect(token).toBeUndefined();
+    expect(store.getSessionItem(StorageKeys.accessToken)).toBeNull();
+    expect(store.getItem(storageMap.user)).toBeNull();
+  });
+
+  it('navigates to logout when no refresh is in flight', async () => {
+    setWindowLocation('', 'app.example.com');
+    mockIsJWTActive.mockReturnValue(true);
+    const activeJwt = makeJwt({exp: Math.floor(Date.now() / 1000) + 600});
+    store.setSessionItem(StorageKeys.accessToken, activeJwt);
+    store.setSessionItem(
+      StorageKeys.idToken,
+      makeJwt({exp: Math.floor(Date.now() / 1000) + 3600})
+    );
+
+    const client = await createKindeClient({
+      domain: 'https://auth.example.com',
+      redirect_uri: 'http://app.example.com/'
+    });
+
+    await client.logout('http://app.example.com/logged-out');
+
+    expect(mockNavigateToKinde).toHaveBeenCalledWith({
+      url: 'https://auth.example.com/logout?redirect=http%3A%2F%2Fapp.example.com%2Flogged-out'
+    });
+    expect(store.getSessionItem(StorageKeys.accessToken)).toBeNull();
   });
 });

--- a/src/createKindeClient.ts
+++ b/src/createKindeClient.ts
@@ -1017,7 +1017,6 @@ const createKindeClient = async (
     localStorage.removeItem(storageMap.refresh_token);
   };
   const init = async () => {
-    console.log('PESICKA, isUseCookie?', isUseCookie);
     try {
       try {
         migrateLegacyRefreshTokenKey();

--- a/src/createKindeClient.ts
+++ b/src/createKindeClient.ts
@@ -222,12 +222,37 @@ const createKindeClient = async (
   };
 
   let inFlightTabCoordination: Promise<RefreshTokenResult> | null = null;
+  // Blocks new refresh/checkAuth work once logout starts. In-flight work is
+  // awaited in logout() so any cookie Set-Cookie lands before /logout clears it.
+  let logoutInProgress = false;
+  let sessionEpoch = 0;
+
+  const isSessionCurrent = (epochAtStart: number): boolean =>
+    !logoutInProgress && epochAtStart === sessionEpoch;
 
   const runTabSyncCoordination = async (
     operation: () => Promise<RefreshTokenResult>,
-    inProgressErrorMessage: string
+    inProgressErrorMessage: string,
+    epochAtStart: number
   ): Promise<RefreshTokenResult> => {
+    if (!isSessionCurrent(epochAtStart)) {
+      return {
+        success: false,
+        error: 'Logout in progress'
+      };
+    }
+
     const lock = await tabSync.tryWithRefreshLock(operation);
+
+    // Logout may have started while the refresh/checkAuth fetch was in flight.
+    // Do not re-apply tokens into memory; logout awaits this promise then clears
+    // storage and navigates to /logout (which clears _kbrte after any Set-Cookie).
+    if (!isSessionCurrent(epochAtStart)) {
+      return {
+        success: false,
+        error: 'Logout in progress'
+      };
+    }
 
     if (lock.ran && isSuccessResult(lock.value)) {
       await tabSync.applyTokensFromResult(lock.value);
@@ -245,6 +270,12 @@ const createKindeClient = async (
     if (waitForPeerTokens) {
       // Another tab holds the lock, or LS lock outcome was ambiguous and refresh failed
       const tokens = await tabSync.waitForTokenBroadcast();
+      if (!isSessionCurrent(epochAtStart)) {
+        return {
+          success: false,
+          error: 'Logout in progress'
+        };
+      }
       if (tokens) {
         await tabSync.applyTokens(tokens);
         return {
@@ -272,13 +303,22 @@ const createKindeClient = async (
     operation: () => Promise<RefreshTokenResult>,
     inProgressErrorMessage: string
   ): Promise<RefreshTokenResult> => {
+    if (logoutInProgress) {
+      return Promise.resolve({
+        success: false,
+        error: 'Logout in progress'
+      });
+    }
+
     if (inFlightTabCoordination) {
       return inFlightTabCoordination;
     }
 
+    const epochAtStart = sessionEpoch;
     const coordination = runTabSyncCoordination(
       operation,
-      inProgressErrorMessage
+      inProgressErrorMessage,
+      epochAtStart
     ).finally(() => {
       if (inFlightTabCoordination === coordination) {
         inFlightTabCoordination = null;
@@ -858,6 +898,22 @@ const createKindeClient = async (
     }
   };
 
+  const clearLocalAuthState = async (): Promise<void> => {
+    await Promise.all([
+      store.removeSessionItem(StorageKeys.idToken),
+      store.removeSessionItem(StorageKeys.accessToken),
+      store.removeSessionItem(StorageKeys.refreshToken),
+      localStorageAdapter.removeSessionItem(StorageKeys.refreshToken),
+      store.removeItems(
+        storageMap.refresh_token,
+        storageMap.access_token,
+        storageMap.id_token,
+        storageMap.user,
+        storageMap.token_bundle
+      )
+    ]);
+  };
+
   const logout = async (options?: string | LogoutOptions) => {
     try {
       const params = new URLSearchParams();
@@ -877,27 +933,29 @@ const createKindeClient = async (
         params.append('redirect', logout_uri || '');
       }
 
-      await Promise.all([
-        store.removeSessionItem(StorageKeys.idToken),
-        store.removeSessionItem(StorageKeys.accessToken),
-        store.removeSessionItem(StorageKeys.refreshToken),
-        localStorageAdapter.removeSessionItem(StorageKeys.refreshToken),
-        store.removeItems(
-          storageMap.refresh_token,
-          storageMap.access_token,
-          storageMap.id_token,
-          storageMap.user,
-          storageMap.token_bundle
-        )
-      ]);
+      // Stop new refreshes/checkAuth. Await any in-flight cookie refresh so its
+      // Set-Cookie cannot land after Kinde /logout has already cleared _kbrte.
+      logoutInProgress = true;
+      sessionEpoch += 1;
+      if (inFlightTabCoordination) {
+        try {
+          await inFlightTabCoordination;
+        } catch {
+          // Ignore refresh/checkAuth failures during logout.
+        }
+      }
 
+      await clearLocalAuthState();
       tabSync.broadcastSessionCleared();
 
       try {
         await navigateToKinde({
           url: `${domain}/logout?${params.toString()}`
         });
+        // Keep logoutInProgress true until the document unloads on redirect.
       } catch (error) {
+        // Navigation failed (e.g. popup blocked); allow refresh/checkAuth again.
+        logoutInProgress = false;
         on_error_callback?.({
           error: 'ERR_POPUP',
           errorDescription: (error as Error).message,
@@ -959,6 +1017,7 @@ const createKindeClient = async (
     localStorage.removeItem(storageMap.refresh_token);
   };
   const init = async () => {
+    console.log('PESICKA, isUseCookie?', isUseCookie);
     try {
       try {
         migrateLegacyRefreshTokenKey();
@@ -1077,12 +1136,18 @@ const createKindeClient = async (
 
   tabSync.setupListeners({
     onTokensUpdated: () => {
+      if (logoutInProgress) {
+        void clearLocalAuthState();
+        return;
+      }
       void hydrateUserFromIdToken();
     }
   });
   tabSync.setupVisibilitySync(() => {
+    if (logoutInProgress) return;
     void runCheckAuthWithTabSync()
       .then(async () => {
+        if (logoutInProgress) return;
         if (await isAuthenticated()) {
           await hydrateUserFromIdToken();
         } else {


### PR DESCRIPTION
# Explain your changes
Because of the tabSync method, it is possible to end up in a state where the user clicks logout, but it returns before a refresh finishes. 

correct intended end state:
local clear + /logout → _kbrte/session gone → no silent re-auth. 
Our fix hardens that against the refresh race; it doesn’t add a separate revoke API beyond navigating to Kinde logout.


_Suppose there is a related issue with enough detail for a reviewer to understand your changes fully. In that case, you can omit an explanation and instead include either “Fixes #XX” or “Updates #XX” where “XX” is the issue number._

# Checklist

- [X] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [X] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
