### PR TITLE
fix: address issues with isAuthenticated and stubExpoSecureStore

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "4.4.0",
       "license": "MIT",
       "dependencies": {
-        "@kinde/js-utils": "^0.31.0",
+        "@kinde/js-utils": "^0.32.0",
         "jwt-decode": "^4.0.0"
       },
       "devDependencies": {
@@ -1751,20 +1751,12 @@
       }
     },
     "node_modules/@kinde/js-utils": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/@kinde/js-utils/-/js-utils-0.31.0.tgz",
-      "integrity": "sha512-TJX1ymowYVVodUjgiiqg8YeZO4tOnHfNF+m59UvMYX1PNg46dbbKLVTdpIvIwCm4StTnbjKsRoCSDV6Tw8DBWA==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@kinde/js-utils/-/js-utils-0.32.0.tgz",
+      "integrity": "sha512-rio1Th67SmbYieJSaBi/W+3W6Rf5edoaJ8oR921X+M40EZX0NvzYSu42WyikesPiqCgWlTMu78WbM12hzyvEnQ==",
       "license": "MIT",
       "dependencies": {
         "@kinde/jwt-decoder": "^0.2.0"
-      },
-      "peerDependencies": {
-        "expo-secure-store": ">=11.0.0"
-      },
-      "peerDependenciesMeta": {
-        "expo-secure-store": {
-          "optional": true
-        }
       }
     },
     "node_modules/@kinde/jwt-decoder": {
@@ -2273,9 +2265,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2290,9 +2279,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2307,9 +2293,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2324,9 +2307,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2341,9 +2321,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2358,9 +2335,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2375,9 +2349,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2392,9 +2363,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2409,9 +2377,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2426,9 +2391,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2443,9 +2405,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2460,9 +2419,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2477,9 +2433,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3157,9 +3110,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3174,9 +3124,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3191,9 +3138,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3208,9 +3152,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3225,9 +3166,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3242,9 +3180,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3259,9 +3194,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3276,9 +3208,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3293,9 +3222,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3310,9 +3236,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
     }
   },
   "scripts": {
-    "rollup": "rollup --config rollup.config.ts --configPlugin @rollup/plugin-typescript",
-    "rollup:types": "rollup --config rollup.types.config.ts --configPlugin @rollup/plugin-typescript",
+    "rollup": "rollup --config rollup.config.ts --configPlugin \"@rollup/plugin-typescript={tsconfig:'./tsconfig.rollup.json'}\"",
+    "rollup:types": "rollup --config rollup.types.config.ts --configPlugin \"@rollup/plugin-typescript={tsconfig:'./tsconfig.rollup.json'}\"",
     "build": "genversion --es6 src/utils/version.ts && npm run rollup && npm run rollup:types",
     "test": "jest",
     "watch": "npm run rollup -- --watch",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
   "homepage": "https://kinde.com",
   "license": "MIT",
   "devDependencies": {
+    "@eslint/js": "^10.0.0",
     "@rollup/plugin-babel": "^7.0.0",
     "@rollup/plugin-json": "^6.0.0",
     "@rollup/plugin-node-resolve": "^16.0.0",
@@ -62,13 +63,11 @@
     "@rollup/plugin-typescript": "^12.0.0",
     "@types/jest": "^30.0.0",
     "@types/node": "^25.6.0",
-    "@eslint/js": "^10.0.0",
     "eslint": "^10.0.0",
     "eslint-config-prettier": "^10.0.0",
     "eslint-plugin-jest": "^29.15.5",
-    "globals": "^17.0.0",
-    "typescript-eslint": "^8.56.0",
     "genversion": "^3.1.1",
+    "globals": "^17.0.0",
     "husky": "^9.0.0",
     "jest": "^30.0.0",
     "lint-staged": "^17.0.0",
@@ -79,7 +78,8 @@
     "rollup-plugin-dts": "^6.0.2",
     "ts-jest": "^29.1.1",
     "ts-node": "^10.9.2",
-    "tslib": "^2.6.2"
+    "tslib": "^2.6.2",
+    "typescript-eslint": "^8.56.0"
   },
   "keywords": [
     "Kinde",
@@ -101,7 +101,7 @@
   },
   "private": false,
   "dependencies": {
-    "@kinde/js-utils": "^0.31.0",
+    "@kinde/js-utils": "^0.32.0",
     "jwt-decode": "^4.0.0"
   }
 }

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -28,10 +28,16 @@ function stubExpoSecureStore() {
   ].join('\n');
   const stubExpr =
     'Promise.resolve({ default: { setItemAsync: async () => {}, getItemAsync: async () => null, deleteItemAsync: async () => {} } })';
+  // Matches dynamic imports even when webpackIgnore / similar comments sit
+  // between `import(` and the module specifier (as in js-utils >= 0.31).
+  const dynamicImportRe =
+    /await\s+import\s*\(\s*[\s\S]*?["']expo-secure-store["']\s*\)/g;
+  const replaceExpoImports = (code: string) =>
+    code.replace(dynamicImportRe, 'await ' + stubExpr);
   return {
     name: 'stub-expo-secure-store',
     order: 'pre',
-    resolveId(id) {
+    resolveId(id: string) {
       if (
         id === 'expo-secure-store' ||
         (typeof id === 'string' && id.includes('expo-secure-store'))
@@ -40,17 +46,23 @@ function stubExpoSecureStore() {
       }
       return null;
     },
-    load(id) {
+    load(id: string) {
       if (id !== EXPO_STUB_ID) return null;
       return stubCode;
     },
-    transform(code, id) {
-      if (!id.includes('expoSecureStore') && !id.includes('expo-secure-store'))
-        return null;
-      const newCode = code.replace(
-        /await\s+import\s*\(\s*[\s\S]*?["']expo-secure-store["']\s*\)/g,
-        'await ' + stubExpr
-      );
+    transform(code: string) {
+      // Match any module whose *code* contains the import — not just files
+      // whose path includes expoSecureStore. js-utils >= 0.31 inlines
+      // ExpoSecureStore into js-utils.js, so a path filter misses it.
+      if (!code.includes('expo-secure-store')) return null;
+      const newCode = replaceExpoImports(code);
+      return newCode !== code ? {code: newCode, map: null} : null;
+    },
+    renderChunk(code: string) {
+      // Final safety net so published ESM/UMD never leave an unresolved
+      // expo-secure-store import for Vite / Rolldown to fail on.
+      if (!code.includes('expo-secure-store')) return null;
+      const newCode = replaceExpoImports(code);
       return newCode !== code ? {code: newCode, map: null} : null;
     }
   };
@@ -94,22 +106,23 @@ export default defineConfig([
         name: 'createKindeClient',
         file: pkg.main,
         format: 'umd',
+        exports: 'named',
         inlineDynamicImports: true,
         plugins: [terser()]
       },
       {
         file: pkg.module,
         format: 'es',
+        exports: 'named',
         inlineDynamicImports: true
       }
     ],
-    external: ['expo-secure-store'],
     plugins: [
       stubExpoSecureStore(),
       resolve(),
       typescript({
-        declarationDir: 'dist/types',
-        rootDir: 'src'
+        tsconfig: './tsconfig.json',
+        declarationDir: 'dist/types'
       }),
       writeUtilsReexports()
     ]

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -1,3 +1,4 @@
+/// <reference types="node" />
 import {createRequire} from 'node:module';
 import {writeFileSync} from 'node:fs';
 import {resolve as pathResolve} from 'node:path';
@@ -9,64 +10,6 @@ import typescript from '@rollup/plugin-typescript';
 const require = createRequire(import.meta.url);
 const pkg = require('./package.json');
 const distDir = pathResolve(process.cwd(), 'dist');
-
-const EXPO_STUB_ID = '\0expo-secure-store-stub';
-
-/**
- * Stub expo-secure-store so the bundle never contains an unresolved dynamic
- * import. js-utils optionally uses it for React Native; in browser/Node/SPA
- * we provide a no-op stub so consumer bundlers (e.g. Vite) don't try to
- * resolve the missing package.
- */
-function stubExpoSecureStore() {
-  const stubCode = [
-    'export default {',
-    '  setItemAsync: async () => {},',
-    '  getItemAsync: async () => null,',
-    '  deleteItemAsync: async () => {}',
-    '};'
-  ].join('\n');
-  const stubExpr =
-    'Promise.resolve({ default: { setItemAsync: async () => {}, getItemAsync: async () => null, deleteItemAsync: async () => {} } })';
-  // Matches dynamic imports even when webpackIgnore / similar comments sit
-  // between `import(` and the module specifier (as in js-utils >= 0.31).
-  const dynamicImportRe =
-    /await\s+import\s*\(\s*[\s\S]*?["']expo-secure-store["']\s*\)/g;
-  const replaceExpoImports = (code: string) =>
-    code.replace(dynamicImportRe, 'await ' + stubExpr);
-  return {
-    name: 'stub-expo-secure-store',
-    order: 'pre',
-    resolveId(id: string) {
-      if (
-        id === 'expo-secure-store' ||
-        (typeof id === 'string' && id.includes('expo-secure-store'))
-      ) {
-        return {id: EXPO_STUB_ID, moduleSideEffects: false};
-      }
-      return null;
-    },
-    load(id: string) {
-      if (id !== EXPO_STUB_ID) return null;
-      return stubCode;
-    },
-    transform(code: string) {
-      // Match any module whose *code* contains the import — not just files
-      // whose path includes expoSecureStore. js-utils >= 0.31 inlines
-      // ExpoSecureStore into js-utils.js, so a path filter misses it.
-      if (!code.includes('expo-secure-store')) return null;
-      const newCode = replaceExpoImports(code);
-      return newCode !== code ? {code: newCode, map: null} : null;
-    },
-    renderChunk(code: string) {
-      // Final safety net so published ESM/UMD never leave an unresolved
-      // expo-secure-store import for Vite / Rolldown to fail on.
-      if (!code.includes('expo-secure-store')) return null;
-      const newCode = replaceExpoImports(code);
-      return newCode !== code ? {code: newCode, map: null} : null;
-    }
-  };
-}
 
 /**
  * After the main bundle is written, emit utils re-export files so that
@@ -118,11 +61,11 @@ export default defineConfig([
       }
     ],
     plugins: [
-      stubExpoSecureStore(),
       resolve(),
       typescript({
         tsconfig: './tsconfig.json',
-        declarationDir: 'dist/types'
+        declarationDir: 'dist/types',
+        rootDir: 'src'
       }),
       writeUtilsReexports()
     ]

--- a/rollup.types.config.ts
+++ b/rollup.types.config.ts
@@ -1,3 +1,4 @@
+/// <reference types="node" />
 import {createRequire} from 'node:module';
 import {defineConfig} from 'rollup';
 import del from 'rollup-plugin-delete';

--- a/src/createKindeClient.test.ts
+++ b/src/createKindeClient.test.ts
@@ -22,7 +22,6 @@ jest.mock('./kindeUtils', () => {
     setInsecureStorage: jest.fn(),
     checkAuth: jest.fn().mockResolvedValue({success: false}),
     exchangeAuthCode: jest.fn().mockResolvedValue({success: true}),
-    isAuthenticated: jest.fn().mockResolvedValue(false),
     getUserProfile: jest.fn().mockResolvedValue(undefined),
     refreshToken: jest.fn().mockResolvedValue({success: false}),
     navigateToKinde: jest.fn().mockImplementation((opts: {url: string}) => {
@@ -39,7 +38,6 @@ import {
   exchangeAuthCode,
   getUserProfile,
   refreshToken,
-  isAuthenticated,
   storageSettings,
   StorageKeys,
   RefreshType,
@@ -55,7 +53,6 @@ const mockCheckAuth = checkAuth as jest.Mock;
 const mockExchangeAuthCode = exchangeAuthCode as jest.Mock;
 const mockGetUserProfile = getUserProfile as jest.Mock;
 const mockRefreshToken = refreshToken as jest.Mock;
-const mockIsAuthenticated = isAuthenticated as jest.Mock;
 const mockNavigateToKinde = navigateToKinde as jest.Mock;
 const mockIsJWTActive = isJWTActive as jest.MockedFunction<typeof isJWTActive>;
 const mockIsTokenValid = isTokenValid as jest.MockedFunction<
@@ -398,8 +395,10 @@ describe('on_session_restore_callback semantics', () => {
     mockCheckAuth.mockClear();
     mockExchangeAuthCode.mockClear();
     mockGetUserProfile.mockReset();
-    mockIsAuthenticated.mockReset();
-    mockIsAuthenticated.mockResolvedValue(false);
+    mockRefreshToken.mockReset();
+    mockRefreshToken.mockResolvedValue({success: false});
+    mockIsJWTActive.mockReset();
+    mockIsJWTActive.mockReturnValue(false);
     store.reset();
     Object.defineProperty(global, 'sessionStorage', {
       value: createStorageMock(),
@@ -421,7 +420,9 @@ describe('on_session_restore_callback semantics', () => {
 
   it('fires session restore callback on non-redirect authenticated load', async () => {
     setWindowLocation();
-    mockIsAuthenticated.mockResolvedValue(true);
+    const activeJwt = makeJwt({exp: Math.floor(Date.now() / 1000) + 3600});
+    store.setSessionItem(StorageKeys.accessToken, activeJwt);
+    mockIsJWTActive.mockReturnValue(true);
     mockGetUserProfile.mockResolvedValue({
       id: 'kp:user-1',
       givenName: 'Test',
@@ -449,7 +450,9 @@ describe('on_session_restore_callback semantics', () => {
 
   it('populates getUser on session restore without callback when id token is present', async () => {
     setWindowLocation();
-    mockIsAuthenticated.mockResolvedValue(true);
+    const activeJwt = makeJwt({exp: Math.floor(Date.now() / 1000) + 3600});
+    store.setSessionItem(StorageKeys.accessToken, activeJwt);
+    mockIsJWTActive.mockReturnValue(true);
     mockGetUserProfile.mockResolvedValue(undefined);
     store.setSessionItem(
       StorageKeys.idToken,
@@ -477,7 +480,6 @@ describe('on_session_restore_callback semantics', () => {
 
   it('does not fetch user profile when session is not authenticated', async () => {
     setWindowLocation();
-    mockIsAuthenticated.mockResolvedValue(false);
 
     await createKindeClient({
       domain: 'https://example.kinde.com',
@@ -489,7 +491,6 @@ describe('on_session_restore_callback semantics', () => {
 
   it('does not hydrate user from stale id token when session is not authenticated', async () => {
     setWindowLocation();
-    mockIsAuthenticated.mockResolvedValue(false);
     store.setSessionItem(
       StorageKeys.idToken,
       makeJwt({
@@ -510,7 +511,6 @@ describe('on_session_restore_callback semantics', () => {
 
   it('clears previously stored user when session is not authenticated on init', async () => {
     setWindowLocation();
-    mockIsAuthenticated.mockResolvedValue(false);
     store.setItem(storageMap.user, {
       id: 'kp:stale-user',
       email: 'stale@x.com',
@@ -594,8 +594,10 @@ describe('visibility sync hydration', () => {
     mockSetActiveStorage.mockReset();
     mockCheckAuth.mockClear();
     mockCheckAuth.mockResolvedValue({success: false});
-    mockIsAuthenticated.mockReset();
-    mockIsAuthenticated.mockResolvedValue(false);
+    mockRefreshToken.mockReset();
+    mockRefreshToken.mockResolvedValue({success: false});
+    mockIsJWTActive.mockReset();
+    mockIsJWTActive.mockReturnValue(false);
     store.reset();
     setupVisibilityBrowserMocks();
     Object.defineProperty(global, 'sessionStorage', {
@@ -684,7 +686,7 @@ describe('visibility sync hydration', () => {
       [StorageKeys.idToken]: idToken,
       [StorageKeys.refreshToken]: 'refresh-token'
     });
-    mockIsAuthenticated.mockResolvedValue(true);
+    mockIsJWTActive.mockReturnValue(true);
 
     const visibilityHandler = (
       document.addEventListener as jest.Mock
@@ -951,6 +953,13 @@ describe('getAccessToken refresh behaviour', () => {
 
   it('deduplicates concurrent getAccessToken refresh attempts in the same tab', async () => {
     setWindowLocation();
+    mockRefreshToken.mockResolvedValue({success: false});
+
+    const client = await createKindeClient({
+      domain,
+      redirect_uri: 'http://localhost:3000/'
+    });
+
     mockIsJWTActive.mockReturnValue(false);
     const expiredJwt = makeJwt({exp: Math.floor(Date.now() / 1000) - 60});
     const freshJwt = makeJwt({exp: Math.floor(Date.now() / 1000) + 300});
@@ -966,11 +975,6 @@ describe('getAccessToken refresh behaviour', () => {
       [StorageKeys.idToken]: makeJwt({
         exp: Math.floor(Date.now() / 1000) + 3600
       })
-    });
-
-    const client = await createKindeClient({
-      domain,
-      redirect_uri: 'http://localhost:3000/'
     });
 
     const [first, second] = await Promise.all([
@@ -1004,6 +1008,129 @@ describe('getAccessToken refresh behaviour', () => {
     expect(token).toBeUndefined();
     expect(store.getSessionItem(StorageKeys.refreshToken)).toBe('rt-keep');
     expect(store.getSessionItem(StorageKeys.accessToken)).toBe(expiredJwt);
+  });
+});
+
+describe('isAuthenticated refresh behaviour', () => {
+  const domain = 'https://example.kinde.com';
+
+  beforeEach(() => {
+    mockSetActiveStorage.mockReset();
+    mockCheckAuth.mockClear();
+    mockCheckAuth.mockResolvedValue({success: false});
+    mockRefreshToken.mockReset();
+    mockIsJWTActive.mockReset();
+    store.reset();
+    Object.defineProperty(global, 'sessionStorage', {
+      value: createStorageMock(),
+      writable: true,
+      configurable: true
+    });
+    Object.defineProperty(global, 'localStorage', {
+      value: createStorageMock(),
+      writable: true,
+      configurable: true
+    });
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    storageSettings.onRefreshHandler = undefined;
+    jest.clearAllMocks();
+  });
+
+  it('returns true when the stored access token is active', async () => {
+    setWindowLocation();
+    mockIsJWTActive.mockReturnValue(true);
+    store.setSessionItem(
+      StorageKeys.accessToken,
+      makeJwt({exp: Math.floor(Date.now() / 1000) + 3600})
+    );
+
+    const client = await createKindeClient({
+      domain,
+      redirect_uri: 'http://localhost:3000/'
+    });
+
+    await expect(client.isAuthenticated()).resolves.toBe(true);
+    expect(mockRefreshToken).not.toHaveBeenCalled();
+  });
+
+  it('uses refreshToken refresh on localhost when the access token is expired', async () => {
+    setWindowLocation();
+    mockIsJWTActive.mockReturnValue(false);
+    const freshJwt = makeJwt({exp: Math.floor(Date.now() / 1000) + 300});
+    store.setSessionItem(
+      StorageKeys.accessToken,
+      makeJwt({exp: Math.floor(Date.now() / 1000) - 60})
+    );
+    mockRefreshToken.mockResolvedValue({
+      success: true,
+      [StorageKeys.accessToken]: freshJwt,
+      [StorageKeys.idToken]: makeJwt({
+        exp: Math.floor(Date.now() / 1000) + 3600
+      })
+    });
+
+    const client = await createKindeClient({
+      domain,
+      redirect_uri: 'http://localhost:3000/'
+    });
+
+    await expect(client.isAuthenticated()).resolves.toBe(true);
+    expect(mockRefreshToken).toHaveBeenCalledWith(
+      expect.objectContaining({refreshType: RefreshType.refreshToken})
+    );
+  });
+
+  it('uses cookie refresh on a production custom domain when the access token is expired', async () => {
+    setWindowLocation('', 'app.example.com');
+    mockIsJWTActive.mockReturnValue(false);
+    const freshJwt = makeJwt({exp: Math.floor(Date.now() / 1000) + 300});
+    store.setSessionItem(
+      StorageKeys.accessToken,
+      makeJwt({exp: Math.floor(Date.now() / 1000) - 60})
+    );
+    mockRefreshToken.mockResolvedValue({
+      success: true,
+      [StorageKeys.accessToken]: freshJwt,
+      [StorageKeys.idToken]: makeJwt({
+        exp: Math.floor(Date.now() / 1000) + 3600
+      })
+    });
+
+    const client = await createKindeClient({
+      domain: 'https://auth.example.com',
+      redirect_uri: 'http://app.example.com/'
+    });
+
+    await expect(client.isAuthenticated()).resolves.toBe(true);
+    expect(mockRefreshToken).toHaveBeenCalledWith(
+      expect.objectContaining({refreshType: RefreshType.cookie})
+    );
+  });
+
+  it('returns false when cookie refresh fails', async () => {
+    setWindowLocation('', 'app.example.com');
+    mockIsJWTActive.mockReturnValue(false);
+    store.setSessionItem(
+      StorageKeys.accessToken,
+      makeJwt({exp: Math.floor(Date.now() / 1000) - 60})
+    );
+    mockRefreshToken.mockResolvedValue({
+      success: false,
+      error: 'No refresh token found'
+    });
+
+    const client = await createKindeClient({
+      domain: 'https://auth.example.com',
+      redirect_uri: 'http://app.example.com/'
+    });
+
+    await expect(client.isAuthenticated()).resolves.toBe(false);
+    expect(mockRefreshToken).toHaveBeenCalledWith(
+      expect.objectContaining({refreshType: RefreshType.cookie})
+    );
   });
 });
 
@@ -1045,6 +1172,13 @@ describe('logout awaits in-flight refresh', () => {
 
   it('awaits an in-flight cookie refresh before navigating to /logout', async () => {
     setWindowLocation('', 'app.example.com');
+    mockRefreshToken.mockResolvedValue({success: false});
+
+    const client = await createKindeClient({
+      domain: 'https://auth.example.com',
+      redirect_uri: 'http://app.example.com/'
+    });
+
     mockIsJWTActive.mockReturnValue(false);
     const expiredJwt = makeJwt({exp: Math.floor(Date.now() / 1000) - 60});
     const freshJwt = makeJwt({exp: Math.floor(Date.now() / 1000) + 300});
@@ -1062,11 +1196,6 @@ describe('logout awaits in-flight refresh', () => {
         resolveRefresh = resolve;
       })
     );
-
-    const client = await createKindeClient({
-      domain: 'https://auth.example.com',
-      redirect_uri: 'http://app.example.com/'
-    });
 
     const accessPromise = client.getAccessToken();
     // Allow the refresh coordination to start and take the in-flight slot.
@@ -1100,6 +1229,13 @@ describe('logout awaits in-flight refresh', () => {
 
   it('does not apply in-flight refresh tokens after logout has started', async () => {
     setWindowLocation('', 'app.example.com');
+    mockRefreshToken.mockResolvedValue({success: false});
+
+    const client = await createKindeClient({
+      domain: 'https://auth.example.com',
+      redirect_uri: 'http://app.example.com/'
+    });
+
     mockIsJWTActive.mockReturnValue(false);
     const expiredJwt = makeJwt({exp: Math.floor(Date.now() / 1000) - 60});
     const freshJwt = makeJwt({exp: Math.floor(Date.now() / 1000) + 300});
@@ -1123,11 +1259,6 @@ describe('logout awaits in-flight refresh', () => {
         resolveRefresh = resolve;
       })
     );
-
-    const client = await createKindeClient({
-      domain: 'https://auth.example.com',
-      redirect_uri: 'http://app.example.com/'
-    });
 
     const accessPromise = client.getAccessToken();
     await Promise.resolve();

--- a/src/createKindeClient.test.ts
+++ b/src/createKindeClient.test.ts
@@ -126,14 +126,6 @@ const seedLocalRefreshToken = (token = 'refresh-token') => {
   );
 };
 
-const seedCookieRefreshToken = (token = 'cookie-refresh-token') => {
-  Object.defineProperty(document, 'cookie', {
-    value: `_kbrte=${token}`,
-    writable: true,
-    configurable: true
-  });
-};
-
 describe('createKindeClient invitation flow', () => {
   beforeEach(() => {
     mockSetActiveStorage.mockReset();
@@ -939,7 +931,6 @@ describe('getAccessToken refresh behaviour', () => {
 
   it('uses cookie refresh on a production custom domain', async () => {
     setWindowLocation('', 'app.example.com');
-    seedCookieRefreshToken();
     mockIsJWTActive.mockReturnValue(false);
     const expiredJwt = makeJwt({exp: Math.floor(Date.now() / 1000) - 60});
     const freshJwt = makeJwt({exp: Math.floor(Date.now() / 1000) + 300});
@@ -1035,15 +1026,62 @@ describe('getAccessToken refresh behaviour', () => {
     mockIsJWTActive.mockReturnValue(false);
     const expiredJwt = makeJwt({exp: Math.floor(Date.now() / 1000) - 60});
     store.setSessionItem(StorageKeys.accessToken, expiredJwt);
+
+    const client = await createKindeClient({
+      domain,
+      redirect_uri: 'http://localhost:3000/'
+    });
+    mockRefreshToken.mockClear();
+
+    const token = await client.getAccessToken();
+
+    expect(token).toBeUndefined();
+    expect(mockRefreshToken).not.toHaveBeenCalled();
+  });
+
+  it('uses cookie refresh from a session marker without reading document.cookie', async () => {
+    setWindowLocation('', 'app.example.com');
     Object.defineProperty(document, 'cookie', {
       value: '',
       writable: true,
       configurable: true
     });
+    mockIsJWTActive.mockReturnValue(false);
+    const expiredJwt = makeJwt({exp: Math.floor(Date.now() / 1000) - 60});
+    const freshJwt = makeJwt({exp: Math.floor(Date.now() / 1000) + 300});
+    store.setSessionItem(StorageKeys.accessToken, expiredJwt);
+    store.setSessionItem(
+      StorageKeys.idToken,
+      makeJwt({exp: Math.floor(Date.now() / 1000) + 3600})
+    );
+    mockRefreshToken.mockResolvedValue({
+      success: true,
+      [StorageKeys.accessToken]: freshJwt,
+      [StorageKeys.idToken]: makeJwt({
+        exp: Math.floor(Date.now() / 1000) + 3600
+      })
+    });
 
     const client = await createKindeClient({
-      domain,
-      redirect_uri: 'http://localhost:3000/'
+      domain: 'https://auth.example.com',
+      redirect_uri: 'http://app.example.com/'
+    });
+
+    const token = await client.getAccessToken();
+
+    expect(mockRefreshToken).toHaveBeenCalledWith(
+      expect.objectContaining({refreshType: RefreshType.cookie})
+    );
+    expect(token).toBe(freshJwt);
+  });
+
+  it('skips cookie refresh when no client-readable session marker exists', async () => {
+    setWindowLocation('', 'app.example.com');
+    mockIsJWTActive.mockReturnValue(false);
+
+    const client = await createKindeClient({
+      domain: 'https://auth.example.com',
+      redirect_uri: 'http://app.example.com/'
     });
     mockRefreshToken.mockClear();
 
@@ -1129,7 +1167,6 @@ describe('isAuthenticated refresh behaviour', () => {
 
   it('uses cookie refresh on a production custom domain when the access token is expired', async () => {
     setWindowLocation('', 'app.example.com');
-    seedCookieRefreshToken();
     mockIsJWTActive.mockReturnValue(false);
     const freshJwt = makeJwt({exp: Math.floor(Date.now() / 1000) + 300});
     store.setSessionItem(
@@ -1157,7 +1194,6 @@ describe('isAuthenticated refresh behaviour', () => {
 
   it('returns false when cookie refresh fails', async () => {
     setWindowLocation('', 'app.example.com');
-    seedCookieRefreshToken();
     mockIsJWTActive.mockReturnValue(false);
     store.setSessionItem(
       StorageKeys.accessToken,
@@ -1218,7 +1254,6 @@ describe('logout awaits in-flight refresh', () => {
 
   it('awaits an in-flight cookie refresh before navigating to /logout', async () => {
     setWindowLocation('', 'app.example.com');
-    seedCookieRefreshToken();
     mockRefreshToken.mockResolvedValue({success: false});
 
     const client = await createKindeClient({
@@ -1276,7 +1311,6 @@ describe('logout awaits in-flight refresh', () => {
 
   it('does not apply in-flight refresh tokens after logout has started', async () => {
     setWindowLocation('', 'app.example.com');
-    seedCookieRefreshToken();
     mockRefreshToken.mockResolvedValue({success: false});
 
     const client = await createKindeClient({

--- a/src/createKindeClient.test.ts
+++ b/src/createKindeClient.test.ts
@@ -118,6 +118,22 @@ const setWindowLocation = (search = '', hostname = 'localhost') => {
   return location;
 };
 
+const LOCAL_REFRESH_TOKEN_KEY = 'kinde_refreshToken0';
+
+const seedLocalRefreshToken = (token = 'refresh-token') => {
+  (global.localStorage.getItem as jest.Mock).mockImplementation(
+    (key: string) => (key === LOCAL_REFRESH_TOKEN_KEY ? token : null)
+  );
+};
+
+const seedCookieRefreshToken = (token = 'cookie-refresh-token') => {
+  Object.defineProperty(document, 'cookie', {
+    value: `_kbrte=${token}`,
+    writable: true,
+    configurable: true
+  });
+};
+
 describe('createKindeClient invitation flow', () => {
   beforeEach(() => {
     mockSetActiveStorage.mockReset();
@@ -891,6 +907,7 @@ describe('getAccessToken refresh behaviour', () => {
 
   it('refreshes and returns a new token when the stored access token is expired', async () => {
     setWindowLocation();
+    seedLocalRefreshToken();
     mockIsJWTActive.mockReturnValue(false);
     const expiredJwt = makeJwt({exp: Math.floor(Date.now() / 1000) - 60});
     const freshJwt = makeJwt({exp: Math.floor(Date.now() / 1000) + 300});
@@ -922,6 +939,7 @@ describe('getAccessToken refresh behaviour', () => {
 
   it('uses cookie refresh on a production custom domain', async () => {
     setWindowLocation('', 'app.example.com');
+    seedCookieRefreshToken();
     mockIsJWTActive.mockReturnValue(false);
     const expiredJwt = makeJwt({exp: Math.floor(Date.now() / 1000) - 60});
     const freshJwt = makeJwt({exp: Math.floor(Date.now() / 1000) + 300});
@@ -953,6 +971,7 @@ describe('getAccessToken refresh behaviour', () => {
 
   it('deduplicates concurrent getAccessToken refresh attempts in the same tab', async () => {
     setWindowLocation();
+    seedLocalRefreshToken();
     mockRefreshToken.mockResolvedValue({success: false});
 
     const client = await createKindeClient({
@@ -989,6 +1008,7 @@ describe('getAccessToken refresh behaviour', () => {
 
   it('returns undefined without clearing storage when refresh fails', async () => {
     setWindowLocation();
+    seedLocalRefreshToken('rt-keep');
     mockIsJWTActive.mockReturnValue(false);
     const expiredJwt = makeJwt({exp: Math.floor(Date.now() / 1000) - 60});
     store.setSessionItem(StorageKeys.accessToken, expiredJwt);
@@ -1008,6 +1028,29 @@ describe('getAccessToken refresh behaviour', () => {
     expect(token).toBeUndefined();
     expect(store.getSessionItem(StorageKeys.refreshToken)).toBe('rt-keep');
     expect(store.getSessionItem(StorageKeys.accessToken)).toBe(expiredJwt);
+  });
+
+  it('skips refresh when no refresh credential is available', async () => {
+    setWindowLocation();
+    mockIsJWTActive.mockReturnValue(false);
+    const expiredJwt = makeJwt({exp: Math.floor(Date.now() / 1000) - 60});
+    store.setSessionItem(StorageKeys.accessToken, expiredJwt);
+    Object.defineProperty(document, 'cookie', {
+      value: '',
+      writable: true,
+      configurable: true
+    });
+
+    const client = await createKindeClient({
+      domain,
+      redirect_uri: 'http://localhost:3000/'
+    });
+    mockRefreshToken.mockClear();
+
+    const token = await client.getAccessToken();
+
+    expect(token).toBeUndefined();
+    expect(mockRefreshToken).not.toHaveBeenCalled();
   });
 });
 
@@ -1058,6 +1101,7 @@ describe('isAuthenticated refresh behaviour', () => {
 
   it('uses refreshToken refresh on localhost when the access token is expired', async () => {
     setWindowLocation();
+    seedLocalRefreshToken();
     mockIsJWTActive.mockReturnValue(false);
     const freshJwt = makeJwt({exp: Math.floor(Date.now() / 1000) + 300});
     store.setSessionItem(
@@ -1085,6 +1129,7 @@ describe('isAuthenticated refresh behaviour', () => {
 
   it('uses cookie refresh on a production custom domain when the access token is expired', async () => {
     setWindowLocation('', 'app.example.com');
+    seedCookieRefreshToken();
     mockIsJWTActive.mockReturnValue(false);
     const freshJwt = makeJwt({exp: Math.floor(Date.now() / 1000) + 300});
     store.setSessionItem(
@@ -1112,6 +1157,7 @@ describe('isAuthenticated refresh behaviour', () => {
 
   it('returns false when cookie refresh fails', async () => {
     setWindowLocation('', 'app.example.com');
+    seedCookieRefreshToken();
     mockIsJWTActive.mockReturnValue(false);
     store.setSessionItem(
       StorageKeys.accessToken,
@@ -1172,6 +1218,7 @@ describe('logout awaits in-flight refresh', () => {
 
   it('awaits an in-flight cookie refresh before navigating to /logout', async () => {
     setWindowLocation('', 'app.example.com');
+    seedCookieRefreshToken();
     mockRefreshToken.mockResolvedValue({success: false});
 
     const client = await createKindeClient({
@@ -1229,6 +1276,7 @@ describe('logout awaits in-flight refresh', () => {
 
   it('does not apply in-flight refresh tokens after logout has started', async () => {
     setWindowLocation('', 'app.example.com');
+    seedCookieRefreshToken();
     mockRefreshToken.mockResolvedValue({success: false});
 
     const client = await createKindeClient({

--- a/src/createKindeClient.test.ts
+++ b/src/createKindeClient.test.ts
@@ -1039,21 +1039,16 @@ describe('getAccessToken refresh behaviour', () => {
     expect(mockRefreshToken).not.toHaveBeenCalled();
   });
 
-  it('uses cookie refresh from a session marker without reading document.cookie', async () => {
+  it('attempts cookie refresh when client-readable session storage is empty', async () => {
     setWindowLocation('', 'app.example.com');
-    Object.defineProperty(document, 'cookie', {
-      value: '',
-      writable: true,
-      configurable: true
-    });
     mockIsJWTActive.mockReturnValue(false);
-    const expiredJwt = makeJwt({exp: Math.floor(Date.now() / 1000) - 60});
     const freshJwt = makeJwt({exp: Math.floor(Date.now() / 1000) + 300});
-    store.setSessionItem(StorageKeys.accessToken, expiredJwt);
-    store.setSessionItem(
-      StorageKeys.idToken,
-      makeJwt({exp: Math.floor(Date.now() / 1000) + 3600})
-    );
+
+    const client = await createKindeClient({
+      domain: 'https://auth.example.com',
+      redirect_uri: 'http://app.example.com/'
+    });
+    mockRefreshToken.mockClear();
     mockRefreshToken.mockResolvedValue({
       success: true,
       [StorageKeys.accessToken]: freshJwt,
@@ -1062,33 +1057,12 @@ describe('getAccessToken refresh behaviour', () => {
       })
     });
 
-    const client = await createKindeClient({
-      domain: 'https://auth.example.com',
-      redirect_uri: 'http://app.example.com/'
-    });
-
     const token = await client.getAccessToken();
 
     expect(mockRefreshToken).toHaveBeenCalledWith(
       expect.objectContaining({refreshType: RefreshType.cookie})
     );
     expect(token).toBe(freshJwt);
-  });
-
-  it('skips cookie refresh when no client-readable session marker exists', async () => {
-    setWindowLocation('', 'app.example.com');
-    mockIsJWTActive.mockReturnValue(false);
-
-    const client = await createKindeClient({
-      domain: 'https://auth.example.com',
-      redirect_uri: 'http://app.example.com/'
-    });
-    mockRefreshToken.mockClear();
-
-    const token = await client.getAccessToken();
-
-    expect(token).toBeUndefined();
-    expect(mockRefreshToken).not.toHaveBeenCalled();
   });
 });
 

--- a/src/createKindeClient.ts
+++ b/src/createKindeClient.ts
@@ -42,7 +42,6 @@ import {
   Scopes,
   setActiveStorage,
   StorageKeys,
-  isAuthenticated as isAuthenticatedFromJsUtils,
   getUserProfile as getUserProfileFromJsUtils,
   LocalStorage,
   checkAuth,
@@ -543,8 +542,7 @@ const createKindeClient = async (
     const value = store.getItem(key);
     if (typeof value === 'string') return value;
     const bundle = store.getItem(storageMap.token_bundle) as
-      | KindeStateTokenBundle
-      | undefined;
+      KindeStateTokenBundle | undefined;
     return key === storageMap.access_token
       ? bundle?.access_token
       : bundle?.id_token;
@@ -614,11 +612,10 @@ const createKindeClient = async (
   };
 
   const isAuthenticated = async () => {
-    return isAuthenticatedFromJsUtils({
-      useRefreshToken: true,
-      domain,
-      clientId: client_id
-    });
+    // Use the same cookie-vs-storage refresh path as getAccessToken.
+    // js-utils isAuthenticated always defaults refreshType to refreshToken,
+    // which fails on custom domains where the refresh token lives in _kbrte.
+    return Boolean(await getAccessToken());
   };
 
   const getPermissions = (): KindePermissions => {

--- a/src/createKindeClient.ts
+++ b/src/createKindeClient.ts
@@ -578,16 +578,22 @@ const createKindeClient = async (
       return typeof tokenToReturn === 'string' ? tokenToReturn : undefined;
     }
 
-    // Match useRefreshToken: only attempt refresh when a credential exists.
+    // Only attempt refresh when a credential / session signal exists.
+    // Cookie refresh uses HttpOnly `_kbrte`, which document.cookie cannot see —
+    // an existing client-readable token in session storage is the session marker.
     const localStorageRefreshToken = isUseLocalStorage
       ? (localStorageAdapter.getSessionItem(
           StorageKeys.refreshToken
         ) as string) ||
         (localStorage.getItem(storageMap.refresh_token) as string)
       : (store.getItem(storageMap.refresh_token) as string);
+    const hasSessionMarker = Boolean(
+      tokenToReturn ||
+      (await store.getSessionItem(StorageKeys.idToken)) ||
+      readLegacyRawToken(storageMap.id_token)
+    );
     const hasRefreshCredential =
-      Boolean(localStorageRefreshToken) ||
-      (isUseCookie && Boolean(hasCookie('_kbrte')));
+      Boolean(localStorageRefreshToken) || (isUseCookie && hasSessionMarker);
     if (!hasRefreshCredential) {
       return undefined;
     }

--- a/src/createKindeClient.ts
+++ b/src/createKindeClient.ts
@@ -578,6 +578,20 @@ const createKindeClient = async (
       return typeof tokenToReturn === 'string' ? tokenToReturn : undefined;
     }
 
+    // Match useRefreshToken: only attempt refresh when a credential exists.
+    const localStorageRefreshToken = isUseLocalStorage
+      ? (localStorageAdapter.getSessionItem(
+          StorageKeys.refreshToken
+        ) as string) ||
+        (localStorage.getItem(storageMap.refresh_token) as string)
+      : (store.getItem(storageMap.refresh_token) as string);
+    const hasRefreshCredential =
+      Boolean(localStorageRefreshToken) ||
+      (isUseCookie && Boolean(hasCookie('_kbrte')));
+    if (!hasRefreshCredential) {
+      return undefined;
+    }
+
     let result: RefreshTokenResult;
     try {
       result = await runRefreshWithTabSync(

--- a/src/createKindeClient.ts
+++ b/src/createKindeClient.ts
@@ -578,22 +578,17 @@ const createKindeClient = async (
       return typeof tokenToReturn === 'string' ? tokenToReturn : undefined;
     }
 
-    // Only attempt refresh when a credential / session signal exists.
-    // Cookie refresh uses HttpOnly `_kbrte`, which document.cookie cannot see —
-    // an existing client-readable token in session storage is the session marker.
+    // Cookie refresh uses HttpOnly `_kbrte`, which JavaScript cannot inspect,
+    // so cookie mode must attempt refresh and let the server validate it.
+    // Other modes can skip refresh when no readable credential exists.
     const localStorageRefreshToken = isUseLocalStorage
       ? (localStorageAdapter.getSessionItem(
           StorageKeys.refreshToken
         ) as string) ||
         (localStorage.getItem(storageMap.refresh_token) as string)
       : (store.getItem(storageMap.refresh_token) as string);
-    const hasSessionMarker = Boolean(
-      tokenToReturn ||
-      (await store.getSessionItem(StorageKeys.idToken)) ||
-      readLegacyRawToken(storageMap.id_token)
-    );
     const hasRefreshCredential =
-      Boolean(localStorageRefreshToken) || (isUseCookie && hasSessionMarker);
+      isUseCookie || Boolean(localStorageRefreshToken);
     if (!hasRefreshCredential) {
       return undefined;
     }

--- a/src/state/tabSync.test.ts
+++ b/src/state/tabSync.test.ts
@@ -319,8 +319,7 @@ describe('tabSync', () => {
     const storageHandler = (
       window.addEventListener as jest.Mock
     ).mock.calls.find(([event]) => event === 'storage')?.[1] as
-      | ((event: StorageEvent) => void)
-      | undefined;
+      ((event: StorageEvent) => void) | undefined;
 
     storageHandler?.({
       key: 'kinde_token_sync',
@@ -341,8 +340,7 @@ describe('tabSync', () => {
     const storageHandler = (
       window.addEventListener as jest.Mock
     ).mock.calls.find(([event]) => event === 'storage')?.[1] as
-      | ((event: StorageEvent) => void)
-      | undefined;
+      ((event: StorageEvent) => void) | undefined;
 
     storageHandler?.({
       key: 'kinde_token_sync',
@@ -376,8 +374,7 @@ describe('tabSync', () => {
     const storageHandler = (
       window.addEventListener as jest.Mock
     ).mock.calls.find(([event]) => event === 'storage')?.[1] as
-      | ((event: StorageEvent) => void)
-      | undefined;
+      ((event: StorageEvent) => void) | undefined;
 
     storageHandler?.({
       key: 'kinde_token_sync',
@@ -408,8 +405,7 @@ describe('tabSync', () => {
     const storageHandler = (
       window.addEventListener as jest.Mock
     ).mock.calls.find(([event]) => event === 'storage')?.[1] as
-      | ((event: StorageEvent) => void)
-      | undefined;
+      ((event: StorageEvent) => void) | undefined;
 
     storageHandler?.({
       key: 'kinde_token_sync',
@@ -430,8 +426,7 @@ describe('tabSync', () => {
     const visibilityHandler = (
       document.addEventListener as jest.Mock
     ).mock.calls.find(([event]) => event === 'visibilitychange')?.[1] as
-      | (() => void)
-      | undefined;
+      (() => void) | undefined;
 
     visibilityHandler?.();
 
@@ -449,8 +444,7 @@ describe('tabSync', () => {
     const visibilityHandler = (
       document.addEventListener as jest.Mock
     ).mock.calls.find(([event]) => event === 'visibilitychange')?.[1] as
-      | (() => void)
-      | undefined;
+      (() => void) | undefined;
     const focusHandler = (window.addEventListener as jest.Mock).mock.calls.find(
       ([event]) => event === 'focus'
     )?.[1] as (() => void) | undefined;
@@ -487,8 +481,7 @@ describe('tabSync', () => {
     const storageHandler = (
       window.addEventListener as jest.Mock
     ).mock.calls.find(([event]) => event === 'storage')?.[1] as
-      | ((event: StorageEvent) => void)
-      | undefined;
+      ((event: StorageEvent) => void) | undefined;
 
     storageHandler?.({
       key: 'kinde_token_sync',
@@ -522,8 +515,7 @@ describe('tabSync', () => {
     const storageHandler = (
       window.addEventListener as jest.Mock
     ).mock.calls.find(([event]) => event === 'storage')?.[1] as
-      | ((event: StorageEvent) => void)
-      | undefined;
+      ((event: StorageEvent) => void) | undefined;
 
     storageHandler?.({
       key: 'kinde_token_sync',

--- a/src/state/tabSync.ts
+++ b/src/state/tabSync.ts
@@ -218,8 +218,7 @@ export const createTabSync = (options: TabSyncOptions): TabSync => {
   };
 
   type RefreshLockResult<T> =
-    | {ran: true; value: T; usedAmbiguousFallback: boolean}
-    | {ran: false};
+    {ran: true; value: T; usedAmbiguousFallback: boolean} | {ran: false};
 
   let sameTabLockAttempt: Promise<RefreshLockResult<unknown>> | null = null;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -100,12 +100,7 @@ export type OrgOptions = {
 };
 
 export type AuthUrlParamValue =
-  | string
-  | number
-  | boolean
-  | bigint
-  | null
-  | undefined;
+  string | number | boolean | bigint | null | undefined;
 
 export type AuthUrlParams = Record<string, AuthUrlParamValue>;
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,11 +2,12 @@
   "compilerOptions": {
     "outDir": "./dist",
     "declarationDir": "./dist/types",
+    "rootDir": "./src",
     "target": "esnext",
     "module": "esnext",
     "types": ["node", "jest"],
     "lib": ["dom", "dom.iterable", "esnext"],
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "esModuleInterop": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,5 +14,5 @@
     "declaration": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "rollup.config.ts", "rollup.types.config.ts"]
+  "exclude": ["node_modules"]
 }

--- a/tsconfig.rollup.json
+++ b/tsconfig.rollup.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": ["node"],
+    "rootDir": "."
+  },
+  "include": ["rollup.config.ts", "rollup.types.config.ts"]
+}


### PR DESCRIPTION
# Explain your changes

## Issues:
The prerelease build was failing with the following errors:

4.5.1-1 doesn't build in a browser app. The ESM bundle contains an unstubbed await import("expo-secure-store") (dist/kinde-auth-pkce-js.esm.js, line 638), which Vite can't resolve:

- dev server: Internal server error: Failed to resolve import "expo-secure-store" — app doesn't load
- unit tests: 4–6 files fail per app
- production build: Rolldown failed to resolve import "expo-secure-store" — hard failure

npm pack @kinde-oss/kinde-auth-pkce-js@4.5.1-1
grep -n "expo-secure-store" package/dist/kinde-auth-pkce-js.esm.js
Not present in 4.5.1-0. Looks like the stubExpoSecureStore() plugin from your rollup.config.ts didn't run for this build. Could we get a 4.5.1-2 with that back in? Happy to test right away.

 isAuthenticated() returning false on callback page: when isUseCookie is true and the refresh token sits in the _kbrte cookie. getAccessToken() handles that (isUseCookie ? cookie : refreshToken), but isAuthenticated() calls the refresh helper without a refreshType, so it defaults to refreshToken, finds nothing in storage and returns "No refresh token found" → false, while the cookie is valid. Only when the access token has already expired, and never on localhost since the refresh token is in local storage there.

## Fixes

1. Unstubbed expo-secure-store in ESM:
    - js-utils 0.31 inlines ExpoSecureStore into js-utils.js, so the stub plugin’s path filter (expoSecureStore in the filename) never matched. Combined with external: ['expo-secure-store'], the dynamic import was left in the bundle.
    - Fix: match on code content, add a renderChunk safety net, and stop marking it as external. Verified: ESM now has the inline stub, not import("expo-secure-store").

2. isAuthenticated() ignoring cookie refresh
    - js-utils isAuthenticated always refreshes with default refreshType: refreshToken, which looks in storage and fails with “No refresh token found” when the token is only in _kbrte.
    - Fix: isAuthenticated() now uses the same path as getAccessToken() (Boolean(await getAccessToken())), so custom domains use RefreshType.cookie.
3. tsconfig.json issues:
    - What changed:
        - tsconfig.json → rootDir: "./src", moduleResolution: "bundler"
        - New tsconfig.rollup.json for loading the Rollup configs
        - exports: "named" on the UMD/ESM outputs


_Suppose there is a related issue with enough detail for a reviewer to understand your changes fully. In that case, you can omit an explanation and instead include either “Fixes #XX” or “Updates #XX” where “XX” is the issue number._

# Checklist

- [X] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [X] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
