### PR TITLE
fix: map legacy org_code option to auth URL in login/register/createOrg

### DIFF
--- a/src/createKindeClient.test.ts
+++ b/src/createKindeClient.test.ts
@@ -194,6 +194,72 @@ describe('createKindeClient invitation flow', () => {
   });
 });
 
+describe('createKindeClient organization redirects', () => {
+  beforeEach(() => {
+    mockSetActiveStorage.mockReset();
+    store.reset();
+    Object.defineProperty(global, 'sessionStorage', {
+      value: createStorageMock(),
+      writable: true,
+      configurable: true
+    });
+    Object.defineProperty(global, 'localStorage', {
+      value: createStorageMock(),
+      writable: true,
+      configurable: true
+    });
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    storageSettings.onRefreshHandler = undefined;
+    jest.clearAllMocks();
+  });
+
+  const createClient = async () => {
+    setWindowLocation();
+    return createKindeClient({
+      domain: 'https://example.kinde.com',
+      redirect_uri: 'http://localhost:3000/'
+    });
+  };
+
+  const redirectedUrl = () =>
+    new URL((window as typeof globalThis & {location: Location}).location.href);
+
+  it('includes org_code in the auth URL when login is called with legacy org_code', async () => {
+    const client = await createClient();
+
+    await client.login({org_code: 'org_snake'});
+
+    expect(redirectedUrl().searchParams.get('org_code')).toBe('org_snake');
+  });
+
+  it('includes org_code in the auth URL when login is called with orgCode', async () => {
+    const client = await createClient();
+
+    await client.login({orgCode: 'org_camel'});
+
+    expect(redirectedUrl().searchParams.get('org_code')).toBe('org_camel');
+  });
+
+  it('includes org_code in the auth URL when register is called with legacy org_code', async () => {
+    const client = await createClient();
+
+    await client.register({org_code: 'org_snake'});
+
+    expect(redirectedUrl().searchParams.get('org_code')).toBe('org_snake');
+  });
+
+  it('legacy org_code takes precedence when both spellings are provided', async () => {
+    const client = await createClient();
+
+    await client.login({org_code: 'org_snake', orgCode: 'org_camel'});
+
+    expect(redirectedUrl().searchParams.get('org_code')).toBe('org_snake');
+  });
+});
+
 describe('refresh token storage routing (expired access → refresh recovery)', () => {
   const domain = 'https://example.kinde.com';
   const redirectUri = 'http://localhost:3000/';

--- a/src/createKindeClient.ts
+++ b/src/createKindeClient.ts
@@ -682,6 +682,7 @@ const createKindeClient = async (
       prompt,
       is_create_org,
       org_name = '',
+      org_code,
       invitation_code,
       authUrlParams = {},
       ...restRedirectOptions
@@ -724,6 +725,10 @@ const createKindeClient = async (
     if (invitation_code) {
       authProps.invitationCode = invitation_code;
       authProps.isInvitation = true;
+    }
+
+    if (org_code) {
+      authProps.orgCode = org_code;
     }
 
     if (is_create_org) {


### PR DESCRIPTION
# Explain your changes

Passing org_code to login(), register() or createOrg() type-checks and is what the docs show, but the option never made it into the authorization URL. generateAuthUrl from @kinde/js-utils only understands the camelCase orgCode key, so the snake_case value was silently ignored. redirectToKinde now converts org_code to orgCode before building the URL, Added tests that check the org_code query param is present in the generated URL for both spellings.

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
